### PR TITLE
Added RejectionException

### DIFF
--- a/src/Promise.php
+++ b/src/Promise.php
@@ -129,7 +129,7 @@ class Promise implements PromiseInterface
         // It's rejected or cancelled, so "unwrap" and throw an exception.
         throw $this->result instanceof \Exception
             ? $this->result
-            : new \RuntimeException($this->result);
+            : new RejectionException($this->result);
     }
 
     public function getState()

--- a/src/RejectionException.php
+++ b/src/RejectionException.php
@@ -1,0 +1,40 @@
+<?php
+namespace GuzzleHttp\Promise;
+
+/**
+ * A special exception that is thrown when waiting on a rejected promise.
+ *
+ * The reason value is available via the getReason() method.
+ */
+class RejectionException extends \RuntimeException
+{
+    /** @var mixed Rejection reason. */
+    private $reason;
+
+    /**
+     * @param mixed $reason Rejection reason.
+     */
+    public function __construct($reason)
+    {
+        $this->reason = $reason;
+
+        $message = 'The promise was rejected';
+        if (is_string($reason)
+            || (is_object($reason) && method_exists($reason, '__toString'))
+        ) {
+            $message .= ' with value: ' . $this->reason;
+        }
+
+        parent::__construct($message);
+    }
+
+    /**
+     * Returns the rejection reason.
+     *
+     * @return mixed
+     */
+    public function getReason()
+    {
+        return $this->reason;
+    }
+}

--- a/tests/PromiseTest.php
+++ b/tests/PromiseTest.php
@@ -65,8 +65,8 @@ class PromiseTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException \RuntimeException
-     * @expectedExceptionMessage foo
+     * @expectedException \GuzzleHttp\Promise\RejectionException
+     * @expectedExceptionMessage The promise was rejected with value: foo
      */
     public function testThrowsWhenUnwrapIsRejectedWithNonException()
     {

--- a/tests/RejectionExceptionTest.php
+++ b/tests/RejectionExceptionTest.php
@@ -1,0 +1,32 @@
+<?php
+namespace GuzzleHttp\Tests;
+
+use GuzzleHttp\Promise\RejectionException;
+
+class Thing
+{
+    public function __construct($message)
+    {
+        $this->message = $message;
+    }
+
+    public function __toString()
+    {
+        return $this->message;
+    }
+}
+
+/**
+ * @covers GuzzleHttp\Promise\RejectionException
+ */
+class RejectionExceptionTest extends \PHPUnit_Framework_TestCase
+{
+    public function testCanGetReasonFromException()
+    {
+        $thing = new Thing('foo');
+        $e = new RejectionException($thing);
+
+        $this->assertSame($thing, $e->getReason());
+        $this->assertEquals('The promise was rejected with value: foo', $e->getMessage());
+    }
+}


### PR DESCRIPTION
Added a `RejectionException` class that allows you to reject a promise with a non-string value in a safe way.