### PR TITLE
Fix conditionally requiring functions.php

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "psr-4": {
             "GuzzleHttp\\Promise\\": "src/"
         },
-        "files": ["src/functions.php"]
+        "files": ["src/functions_include.php"]
     },
     "extra": {
         "branch-alias": {

--- a/src/functions.php
+++ b/src/functions.php
@@ -1,11 +1,6 @@
 <?php
 namespace GuzzleHttp\Promise;
 
-// Don't redefine the functions if included multiple times.
-if (function_exists('GuzzleHttp\Promise\promise_for')) {
-    return;
-}
-
 /**
  * Get the global task queue used for promise resolution.
  *

--- a/src/functions_include.php
+++ b/src/functions_include.php
@@ -1,0 +1,6 @@
+<?php
+
+// Don't redefine the functions if included multiple times.
+if (!function_exists('GuzzleHttp\Promise\promise_for')) {
+    require __DIR__ . '/functions.php';
+}


### PR DESCRIPTION
The solution currently being used for conditionally autoloading functions does not work: PHP will attempt to load the functions before the conditional is evaluated. React had a similar problem (see reactphp/promise#25) which which was solved using a shim `functions_include.php` file that checks for the existence of the first function within `functions.php` before including `functions.php`. This PR modifies the conditional require to use React's method.