### PR TITLE
Add support for HHVM.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,9 @@ php:
 
 sudo: false
 
+before_script:
+  - if [[ "$TRAVIS_PHP_VERSION" = "hhv*" ]]; then find . -type f -name "*.php" -exec sed -i '' 's/(\(yield .*\));/\1;/g' {} +; fi
+
 install:
   - travis_retry composer install --no-interaction --prefer-source
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 1.0.2 - 2015-05-15
+
+* Conditionally require functions.php.
+
 ## 1.0.1 - 2015-06-24
 
 * Updating EachPromise to call next on the underlying promise iterator as late

--- a/tests/functionsTest.php
+++ b/tests/functionsTest.php
@@ -509,13 +509,16 @@ class FunctionsTest extends \PHPUnit_Framework_TestCase
 
         $promise = P\coroutine(function () use ($promises) {
             $value = null;
-            $this->assertEquals('skip', (yield new P\FulfilledPromise('skip')));
+            $skip =  (yield new P\FulfilledPromise('skip'));
+            $this->assertEquals('skip', $skip);
             foreach ($promises as $idx => $p) {
                 $value = (yield $p);
                 $this->assertEquals($value, $idx);
-                $this->assertEquals('skip', (yield new P\FulfilledPromise('skip')));
+                $skip =  (yield new P\FulfilledPromise('skip'));
+                $this->assertEquals('skip', $skip);
             }
-            $this->assertEquals('skip', (yield new P\FulfilledPromise('skip')));
+            $skip =  (yield new P\FulfilledPromise('skip'));
+            $this->assertEquals('skip', $skip);
             yield $value;
         });
 


### PR DESCRIPTION
When https://github.com/facebook/hhvm/pull/4915 hits then we won't need to call `next` any more on versions after that version.  Later, we won't need to use `raise` instead of `throw`.

Changes to the test case were due to https://github.com/facebook/hhvm/issues/1627.  While this doesn't work in HHVM, it allows us to use `sed -e 's/(\(yield .*\));/\1;/g'` to change the PHP files to be HHVM parseable.
