### PR TITLE
Immediately resolve each promises that are passed an empty iterator

### DIFF
--- a/src/EachPromise.php
+++ b/src/EachPromise.php
@@ -83,6 +83,11 @@ class EachPromise implements PromisorInterface
     {
         $this->aggregate = new Promise(function () {
             reset($this->pending);
+            if (empty($this->pending) && !$this->iterable->valid()) {
+                $this->aggregate->resolve(null);
+                return;
+            }
+
             // Consume a potentially fluctuating list of promises while
             // ensuring that indexes are maintained (precluding array_shift).
             while ($promise = current($this->pending)) {

--- a/tests/EachPromiseTest.php
+++ b/tests/EachPromiseTest.php
@@ -160,6 +160,12 @@ class EachPromiseTest extends \PHPUnit_Framework_TestCase
         $this->markTestIncomplete();
     }
 
+    public function testFulfillsImmediatelyWhenGivenAnEmptyIterator()
+    {
+        $each = new EachPromise(new \ArrayIterator([]));
+        $result = $each->promise()->wait();
+    }
+
     public function testDoesNotBlowStackWithFulfilledPromises()
     {
         $pending = [];


### PR DESCRIPTION
Currently, creating an instance of `EachPromise` with an empty iterator will cause a `RejectionException` to be thrown with the following message: "The promise was rejected with reason: Invoking the wait callback did not resolve the promise." This PR changes that behavior so that such promises are simply resolved as no-ops.