### PR TITLE
Allow recursive waiting without unwrapping exceptions

### DIFF
--- a/src/Promise.php
+++ b/src/Promise.php
@@ -61,17 +61,19 @@ class Promise implements PromiseInterface
     {
         $this->waitIfPending();
 
-        if (!$unwrap) {
-            return null;
-        }
+        $inner = $this->result instanceof PromiseInterface
+            ? $this->result->wait($unwrap)
+            : $this->result;
 
-        if ($this->result instanceof PromiseInterface) {
-            return $this->result->wait($unwrap);
-        } elseif ($this->state === self::FULFILLED) {
-            return $this->result;
-        } else {
-            // It's rejected so "unwrap" and throw an exception.
-            throw exception_for($this->result);
+        if ($unwrap) {
+            if ($this->result instanceof PromiseInterface
+                || $this->state === self::FULFILLED
+            ) {
+                return $inner;
+            } else {
+                // It's rejected so "unwrap" and throw an exception.
+                throw exception_for($inner);
+            }
         }
     }
 

--- a/tests/PromiseTest.php
+++ b/tests/PromiseTest.php
@@ -172,6 +172,18 @@ class PromiseTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('Whoop', $p->wait());
     }
 
+    public function testWaitsOnAPromiseChainEvenWhenNotUnwrapped()
+    {
+        $p2 = new Promise(function () use (&$p2) {
+            $p2->reject('Fail');
+        });
+        $p = new Promise(function () use ($p2, &$p) {
+            $p->resolve($p2);
+        });
+        $p->wait(false);
+        $this->assertSame(Promise::REJECTED, $p2->getState());
+    }
+
     public function testCannotCancelNonPending()
     {
         $p = new Promise();


### PR DESCRIPTION
When calling `wait` on promise, a consumer can choose to forgo unwrapping. Currently, this means both that exceptions are not thrown and that inner promises are not themselves unwrapped. I'm not sure if this is the right approach, but there should be a way to wait on outstanding promises without converting failed promises into exceptions.