### PR TITLE
phpdoc var hint

### DIFF
--- a/src/TaskQueue.php
+++ b/src/TaskQueue.php
@@ -56,6 +56,7 @@ class TaskQueue
      */
     public function run()
     {
+        /** @var callable $task */
         while ($task = array_shift($this->queue)) {
             $task();
         }


### PR DESCRIPTION
Some IDEs signal a warning on executing `$task()` when not explicitly hinting `$task` as `callable`.