### PR TITLE
Handle \Throwable in the same way as \Exception

### DIFF
--- a/src/EachPromise.php
+++ b/src/EachPromise.php
@@ -75,6 +75,8 @@ class EachPromise implements PromisorInterface
             $this->createPromise();
             $this->iterable->rewind();
             $this->refillPending();
+        } catch (\Throwable $e) {
+            $this->aggregate->reject($e);
         } catch (\Exception $e) {
             $this->aggregate->reject($e);
         }
@@ -185,6 +187,10 @@ class EachPromise implements PromisorInterface
             $this->iterable->next();
             $this->mutex = false;
             return true;
+        } catch (\Throwable $e) {
+            $this->aggregate->reject($e);
+            $this->mutex = false;
+            return false;
         } catch (\Exception $e) {
             $this->aggregate->reject($e);
             $this->mutex = false;

--- a/src/FulfilledPromise.php
+++ b/src/FulfilledPromise.php
@@ -37,6 +37,8 @@ class FulfilledPromise implements PromiseInterface
             if ($p->getState() === self::PENDING) {
                 try {
                     $p->resolve($onFulfilled($value));
+                } catch (\Throwable $e) {
+                    $p->reject($e);
                 } catch (\Exception $e) {
                     $p->reject($e);
                 }

--- a/src/Promise.php
+++ b/src/Promise.php
@@ -95,6 +95,8 @@ class Promise implements PromiseInterface
             $this->cancelFn = null;
             try {
                 $fn();
+            } catch (\Throwable $e) {
+                $this->reject($e);
             } catch (\Exception $e) {
                 $this->reject($e);
             }
@@ -206,6 +208,8 @@ class Promise implements PromiseInterface
                 // Forward rejections down the chain.
                 $promise->reject($value);
             }
+        } catch (\Throwable $reason) {
+            $promise->reject($reason);
         } catch (\Exception $reason) {
             $promise->reject($reason);
         }

--- a/src/RejectedPromise.php
+++ b/src/RejectedPromise.php
@@ -38,6 +38,9 @@ class RejectedPromise implements PromiseInterface
                 try {
                     // Return a resolved promise if onRejected does not throw.
                     $p->resolve($onRejected($reason));
+                } catch (\Throwable $e) {
+                    // onRejected threw, so return a rejected promise.
+                    $p->reject($e);
                 } catch (\Exception $e) {
                     // onRejected threw, so return a rejected promise.
                     $p->reject($e);

--- a/src/functions.php
+++ b/src/functions.php
@@ -42,6 +42,8 @@ function task(callable $task)
     $queue->add(function () use ($task, $promise) {
         try {
             $promise->resolve($task());
+        } catch (\Throwable $e) {
+            $promise->reject($e);
         } catch (\Exception $e) {
             $promise->reject($e);
         }
@@ -97,11 +99,11 @@ function rejection_for($reason)
  *
  * @param mixed $reason
  *
- * @return \Exception
+ * @return \Exception|\Throwable
  */
 function exception_for($reason)
 {
-    return $reason instanceof \Exception
+    return $reason instanceof \Exception || $reason instanceof \Throwable
         ? $reason
         : new RejectionException($reason);
 }
@@ -147,6 +149,8 @@ function inspect(PromiseInterface $promise)
         ];
     } catch (RejectionException $e) {
         return ['state' => PromiseInterface::REJECTED, 'reason' => $e->getReason()];
+    } catch (\Throwable $e) {
+        return ['state' => PromiseInterface::REJECTED, 'reason' => $e];
     } catch (\Exception $e) {
         return ['state' => PromiseInterface::REJECTED, 'reason' => $e];
     }
@@ -184,6 +188,7 @@ function inspect_all($promises)
  *
  * @return array
  * @throws \Exception on error
+ * @throws \Throwable on error in PHP >=7
  */
 function unwrap($promises)
 {


### PR DESCRIPTION
This is a great promises library, but there are issues using it in PHP7 right now as `\Error`s are not handled by the library (the base error class in PHP7 is `\Throwable`, not `\Exception` as in PHP5). This PR simply adds support for rejecting promises with errors which inherit from `\Error` and not `\Exception`. This PR is backwards-compatible. 