### PR TITLE
Make it possible to specify a new queue instance

### DIFF
--- a/src/TaskQueue.php
+++ b/src/TaskQueue.php
@@ -48,6 +48,17 @@ class TaskQueue implements TaskQueueInterface
         }
     }
 
+    /**
+     * The task queue will be run and exhausted by default when the process
+     * exits IFF the exit is not the result of a PHP E_ERROR error.
+     *
+     * You can disable running the automatic shutdown of the queue by calling
+     * this function. If you disable the task queue shutdown process, then you
+     * MUST either run the task queue (as a result of running your event loop
+     * or manually using the run() method) or wait on each outstanding promise.
+     *
+     * Note: This shutdown will occur before any destructors are triggered.
+     */
     public function disableShutdown()
     {
         $this->enableShutdown = false;

--- a/src/TaskQueue.php
+++ b/src/TaskQueue.php
@@ -10,7 +10,7 @@ namespace GuzzleHttp\Promise;
  *
  *     GuzzleHttp\Promise\queue()->run();
  */
-class TaskQueue
+class TaskQueue implements TaskQueueInterface
 {
     private $enableShutdown = true;
     private $queue = [];
@@ -30,30 +30,16 @@ class TaskQueue
         }
     }
 
-    /**
-     * Returns true if the queue is empty.
-     *
-     * @return bool
-     */
     public function isEmpty()
     {
         return !$this->queue;
     }
 
-    /**
-     * Adds a task to the queue that will be executed the next time run is
-     * called.
-     *
-     * @param callable $task
-     */
     public function add(callable $task)
     {
         $this->queue[] = $task;
     }
 
-    /**
-     * Execute all of the pending task in the queue.
-     */
     public function run()
     {
         /** @var callable $task */
@@ -62,17 +48,6 @@ class TaskQueue
         }
     }
 
-    /**
-     * The task queue will be run and exhausted by default when the process
-     * exits IFF the exit is not the result of a PHP E_ERROR error.
-     *
-     * You can disable running the automatic shutdown of the queue by calling
-     * this function. If you disable the task queue shutdown process, then you
-     * MUST either run the task queue (as a result of running your event loop
-     * or manually using the run() method) or wait on each outstanding promise.
-     *
-     * Note: This shutdown will occur before any destructors are triggered.
-     */
     public function disableShutdown()
     {
         $this->enableShutdown = false;

--- a/src/TaskQueueInterface.php
+++ b/src/TaskQueueInterface.php
@@ -1,0 +1,38 @@
+<?php
+namespace GuzzleHttp\Promise;
+
+interface TaskQueueInterface
+{
+    /**
+     * Returns true if the queue is empty.
+     *
+     * @return bool
+     */
+    public function isEmpty();
+
+    /**
+     * Adds a task to the queue that will be executed the next time run is
+     * called.
+     *
+     * @param callable $task
+     */
+    public function add(callable $task);
+
+    /**
+     * Execute all of the pending task in the queue.
+     */
+    public function run();
+
+    /**
+     * The task queue will be run and exhausted by default when the process
+     * exits IFF the exit is not the result of a PHP E_ERROR error.
+     *
+     * You can disable running the automatic shutdown of the queue by calling
+     * this function. If you disable the task queue shutdown process, then you
+     * MUST either run the task queue (as a result of running your event loop
+     * or manually using the run() method) or wait on each outstanding promise.
+     *
+     * Note: This shutdown will occur before any destructors are triggered.
+     */
+    public function disableShutdown();
+}

--- a/src/TaskQueueInterface.php
+++ b/src/TaskQueueInterface.php
@@ -22,17 +22,4 @@ interface TaskQueueInterface
      * Execute all of the pending task in the queue.
      */
     public function run();
-
-    /**
-     * The task queue will be run and exhausted by default when the process
-     * exits IFF the exit is not the result of a PHP E_ERROR error.
-     *
-     * You can disable running the automatic shutdown of the queue by calling
-     * this function. If you disable the task queue shutdown process, then you
-     * MUST either run the task queue (as a result of running your event loop
-     * or manually using the run() method) or wait on each outstanding promise.
-     *
-     * Note: This shutdown will occur before any destructors are triggered.
-     */
-    public function disableShutdown();
 }

--- a/src/functions.php
+++ b/src/functions.php
@@ -14,11 +14,11 @@ namespace GuzzleHttp\Promise;
  * }
  * </code>
  *
- * @param $assign Optionally specify a new queue instance.
+ * @param TaskQueueInterface $assign Optionally specify a new queue instance.
  *
- * @return TaskQueue
+ * @return TaskQueueInterface
  */
-function queue(TaskQueue $assign = null)
+function queue(TaskQueueInterface $assign = null)
 {
     static $queue;
 

--- a/src/functions.php
+++ b/src/functions.php
@@ -14,13 +14,17 @@ namespace GuzzleHttp\Promise;
  * }
  * </code>
  *
+ * @param $assign Optionally specify a new queue instance.
+ *
  * @return TaskQueue
  */
-function queue()
+function queue(TaskQueue $assign = null)
 {
     static $queue;
 
-    if (!$queue) {
+    if ($assign) {
+        $queue = $assign;
+    } elseif (!$queue) {
         $queue = new TaskQueue();
     }
 


### PR DESCRIPTION
In order to enable efficient integrations with reactors, it would be very helpful to be able to provide a custom task queue.

Here's a simple example of what would be possible after merging this PR:

```php
use Amp\Reactor;
use GuzzleHttp\Promise\TaskQueue;

class AmpTaskQueue extends TaskQueue
{
    private $reactor;

    public function __construct(Reactor $reactor)
    {
        $this->reactor = $reactor;
    }

    public function add(callable $task)
    {
        if ($this->isEmpty()) {
            $this->reactor->immediately([$this, 'run']);
        }

        parent::add($task);
    }
}

\GuzzleHttp\Promise\queue(new AmpTaskQueue($reactor));
```

Simply calling `$reactor->immedately($task);` would really be preferable but, unfortunately, this would prevent the `run()` and `isEmpty()` methods from working as expected.