### PR TITLE
Fix: memory leak in coroutine function due to promise chaining

### DIFF
--- a/src/TaskQueue.php
+++ b/src/TaskQueue.php
@@ -10,7 +10,7 @@ namespace GuzzleHttp\Promise;
  *
  *     GuzzleHttp\Promise\queue()->run();
  */
-class TaskQueue
+class TaskQueue implements TaskQueueInterface
 {
     private $enableShutdown = true;
     private $queue = [];
@@ -30,30 +30,16 @@ class TaskQueue
         }
     }
 
-    /**
-     * Returns true if the queue is empty.
-     *
-     * @return bool
-     */
     public function isEmpty()
     {
         return !$this->queue;
     }
 
-    /**
-     * Adds a task to the queue that will be executed the next time run is
-     * called.
-     *
-     * @param callable $task
-     */
     public function add(callable $task)
     {
         $this->queue[] = $task;
     }
 
-    /**
-     * Execute all of the pending task in the queue.
-     */
     public function run()
     {
         /** @var callable $task */
@@ -62,17 +48,6 @@ class TaskQueue
         }
     }
 
-    /**
-     * The task queue will be run and exhausted by default when the process
-     * exits IFF the exit is not the result of a PHP E_ERROR error.
-     *
-     * You can disable running the automatic shutdown of the queue by calling
-     * this function. If you disable the task queue shutdown process, then you
-     * MUST either run the task queue (as a result of running your event loop
-     * or manually using the run() method) or wait on each outstanding promise.
-     *
-     * Note: This shutdown will occur before any destructors are triggered.
-     */
     public function disableShutdown()
     {
         $this->enableShutdown = false;

--- a/src/TaskQueueInterface.php
+++ b/src/TaskQueueInterface.php
@@ -1,0 +1,38 @@
+<?php
+namespace GuzzleHttp\Promise;
+
+interface TaskQueueInterface
+{
+    /**
+     * Returns true if the queue is empty.
+     *
+     * @return bool
+     */
+    public function isEmpty();
+
+    /**
+     * Adds a task to the queue that will be executed the next time run is
+     * called.
+     *
+     * @param callable $task
+     */
+    public function add(callable $task);
+
+    /**
+     * Execute all of the pending task in the queue.
+     */
+    public function run();
+
+    /**
+     * The task queue will be run and exhausted by default when the process
+     * exits IFF the exit is not the result of a PHP E_ERROR error.
+     *
+     * You can disable running the automatic shutdown of the queue by calling
+     * this function. If you disable the task queue shutdown process, then you
+     * MUST either run the task queue (as a result of running your event loop
+     * or manually using the run() method) or wait on each outstanding promise.
+     *
+     * Note: This shutdown will occur before any destructors are triggered.
+     */
+    public function disableShutdown();
+}

--- a/src/functions.php
+++ b/src/functions.php
@@ -14,11 +14,11 @@ namespace GuzzleHttp\Promise;
  * }
  * </code>
  *
- * @param $assign Optionally specify a new queue instance.
+ * @param TaskQueueInterface $assign Optionally specify a new queue instance.
  *
- * @return TaskQueue
+ * @return TaskQueueInterface
  */
-function queue(TaskQueue $assign = null)
+function queue(TaskQueueInterface $assign = null)
 {
     static $queue;
 

--- a/src/functions.php
+++ b/src/functions.php
@@ -482,23 +482,44 @@ function is_settled(PromiseInterface $promise)
 function coroutine(callable $generatorFn)
 {
     $generator = $generatorFn();
-    return __next_coroutine($generator->current(), $generator)->then();
+    $state = new \stdClass;
+    $state->resultPlaceholder = new Promise(function () use ($state) {
+        while (isset($state->currentPromise)) {
+            $state->currentPromise->wait();
+        }
+    });
+    __next_coroutine($generator->current(), $generator, $state);
+    return $state->resultPlaceholder;
 }
 
 /** @internal */
-function __next_coroutine($yielded, \Generator $generator)
+function __next_coroutine($yielded, \Generator $generator, \stdClass $state)
 {
-    return promise_for($yielded)->then(
-        function ($value) use ($generator) {
-            $nextYield = $generator->send($value);
-            return $generator->valid()
-                ? __next_coroutine($nextYield, $generator)
-                : $value;
+    $state->currentPromise = promise_for($yielded)->then(
+        function ($value) use ($generator, $state) {
+            unset($state->currentPromise);
+
+            try {
+                $nextYield = $generator->send($value);
+                if ($generator->valid()) {
+                    __next_coroutine($nextYield, $generator, $state);
+                } else {
+                    $state->resultPlaceholder->resolve($value);
+                }
+            } catch (\Throwable $e) {
+                $state->resultPlaceholder->reject($e);
+            }
         },
-        function ($reason) use ($generator) {
-            $nextYield = $generator->throw(exception_for($reason));
-            // The throw was caught, so keep iterating on the coroutine
-            return __next_coroutine($nextYield, $generator);
+        function ($reason) use ($generator, $state) {
+            unset($state->currentPromise);
+
+            try {
+                $nextYield = $generator->throw(exception_for($reason));
+                // The throw was caught, so keep iterating on the coroutine
+                __next_coroutine($nextYield, $generator, $state);
+            } catch (\Throwable $e) {
+                $state->resultPlaceholder->reject($e);
+            }
         }
     );
 }

--- a/src/functions.php
+++ b/src/functions.php
@@ -14,13 +14,17 @@ namespace GuzzleHttp\Promise;
  * }
  * </code>
  *
+ * @param $assign Optionally specify a new queue instance.
+ *
  * @return TaskQueue
  */
-function queue()
+function queue(TaskQueue $assign = null)
 {
     static $queue;
 
-    if (!$queue) {
+    if ($assign) {
+        $queue = $assign;
+    } elseif (!$queue) {
         $queue = new TaskQueue();
     }
 


### PR DESCRIPTION
The current coroutine implementation uses a promise chain which gets longer each time the generator function `yield`s. The following code snippet will cause huge memory usage with the current coroutine implementation:

```php
coroutine(function () {
    for ($i = 0; $i < 1e6; $i++) {
        yield $i;
    }
})->wait();
```

This backwards-compatible PR changes the coroutine implementation so that promises are no-longer chained together, which allows infinite `yield`s from within coroutine generator functions.