### PR TITLE
Fix: memory leak in coroutine function due to promise chaining

### DIFF
--- a/src/functions.php
+++ b/src/functions.php
@@ -504,6 +504,8 @@ function __next_coroutine($yielded, \Generator $generator, \stdClass $state)
                 }
             } catch (\Throwable $e) {
                 $state->resultPlaceholder->reject($e);
+            } catch (\Exception $e) {
+                $state->resultPlaceholder->reject($e);
             }
         },
         function ($reason) use ($generator, $state) {
@@ -514,6 +516,8 @@ function __next_coroutine($yielded, \Generator $generator, \stdClass $state)
                 // The throw was caught, so keep iterating on the coroutine
                 __next_coroutine($nextYield, $generator, $state);
             } catch (\Throwable $e) {
+                $state->resultPlaceholder->reject($e);
+            } catch (\Exception $e) {
                 $state->resultPlaceholder->reject($e);
             }
         }


### PR DESCRIPTION
The current coroutine implementation creates a promise chain which gets longer each time the generator function `yield`s. The following code snippet will cause huge memory usage with the current coroutine implementation:

```php
coroutine(function () {
    for ($i = 0; $i < 1e6; $i++) {
        yield $i;
    }
})->wait();
```

This backwards-compatible PR changes the coroutine implementation so that promises are no-longer chained together, which allows infinite `yield`s from within coroutine generator functions.