### PR TITLE
Fix coroutine memory leak

### DIFF
--- a/src/Coroutine.php
+++ b/src/Coroutine.php
@@ -1,0 +1,118 @@
+<?php
+namespace GuzzleHttp\Promise;
+
+use Exception;
+use Generator;
+use Throwable;
+
+/**
+ * Creates a promise that is resolved using a generator that yields values or
+ * promises (somewhat similar to C#'s async keyword).
+ *
+ * When called, the coroutine function will start an instance of the generator
+ * and returns a promise that is fulfilled with its final yielded value.
+ *
+ * Control is returned back to the generator when the yielded promise settles.
+ * This can lead to less verbose code when doing lots of sequential async calls
+ * with minimal processing in between.
+ *
+ *     use GuzzleHttp\Promise;
+ *
+ *     function createPromise($value) {
+ *         return new Promise\FulfilledPromise($value);
+ *     }
+ *
+ *     $promise = Promise\coroutine(function () {
+ *         $value = (yield createPromise('a'));
+ *         try {
+ *             $value = (yield createPromise($value . 'b'));
+ *         } catch (\Exception $e) {
+ *             // The promise was rejected.
+ *         }
+ *         yield $value . 'c';
+ *     });
+ *
+ *     // Outputs "abc"
+ *     $promise->then(function ($v) { echo $v; });
+ *
+ * @param callable $generatorFn Generator function to wrap into a promise.
+ *
+ * @return Promise
+ * @link https://github.com/petkaantonov/bluebird/blob/master/API.md#generators inspiration
+ */
+final class Coroutine implements PromisorInterface
+{
+    /**
+     * @var PromiseInterface|null
+     */
+    private $currentPromise;
+
+    /**
+     * @var Generator
+     */
+    private $generator;
+
+    /**
+     * @var Promise
+     */
+    private $result;
+
+    public function __construct(callable $generatorFn)
+    {
+        $this->generator = $generatorFn();
+        $this->result = new Promise(function () {
+            while (isset($this->currentPromise)) {
+                $this->currentPromise->wait(false);
+            }
+        });
+    }
+
+    public function promise()
+    {
+        $this->nextCoroutine($this->generator->current());
+        return $this->result;
+    }
+
+    private function nextCoroutine($yielded)
+    {
+        $this->currentPromise = promise_for($yielded)
+            ->then([$this, '_handleSuccess'], [$this, '_handleFailure']);
+    }
+
+    /**
+     * @internal
+     */
+    public function _handleSuccess($value)
+    {
+        unset($this->currentPromise);
+        try {
+            $next = $this->generator->send($value);
+            if ($this->generator->valid()) {
+                $this->nextCoroutine($next);
+            } else {
+                $this->result->resolve($value);
+            }
+        } catch (Exception $exception) {
+            $this->result->reject($exception);
+        } catch (Throwable $throwable) {
+            $this->result->reject($throwable);
+        }
+    }
+
+    /**
+     * @internal
+     */
+    public function _handleFailure($reason)
+    {
+        unset($this->currentPromise);
+        try {
+            $nextYield = $this->generator->throw(exception_for($reason));
+            // The throw was caught, so keep iterating on the coroutine
+            $this->nextCoroutine($nextYield);
+        } catch (Exception $exception) {
+            $this->result->reject($exception);
+        } catch (Throwable $throwable) {
+            $this->result->reject($throwable);
+        }
+    }
+}

--- a/src/functions.php
+++ b/src/functions.php
@@ -449,5 +449,5 @@ function is_settled(PromiseInterface $promise)
  */
 function coroutine(callable $generatorFn)
 {
-    return (new Coroutine($generatorFn))->promise();
+    return new Coroutine($generatorFn);
 }

--- a/src/functions.php
+++ b/src/functions.php
@@ -478,23 +478,48 @@ function is_settled(PromiseInterface $promise)
 function coroutine(callable $generatorFn)
 {
     $generator = $generatorFn();
-    return __next_coroutine($generator->current(), $generator)->then();
+    $state = new \stdClass;
+    $state->resultPlaceholder = new Promise(function () use ($state) {
+        while (isset($state->currentPromise)) {
+            $state->currentPromise->wait();
+        }
+    });
+    __next_coroutine($generator->current(), $generator, $state);
+    return $state->resultPlaceholder;
 }
 
 /** @internal */
-function __next_coroutine($yielded, \Generator $generator)
+function __next_coroutine($yielded, \Generator $generator, \stdClass $state)
 {
-    return promise_for($yielded)->then(
-        function ($value) use ($generator) {
-            $nextYield = $generator->send($value);
-            return $generator->valid()
-                ? __next_coroutine($nextYield, $generator)
-                : $value;
+    $state->currentPromise = promise_for($yielded)->then(
+        function ($value) use ($generator, $state) {
+            unset($state->currentPromise);
+
+            try {
+                $nextYield = $generator->send($value);
+                if ($generator->valid()) {
+                    __next_coroutine($nextYield, $generator, $state);
+                } else {
+                    $state->resultPlaceholder->resolve($value);
+                }
+            } catch (\Throwable $e) {
+                $state->resultPlaceholder->reject($e);
+            } catch (\Exception $e) {
+                $state->resultPlaceholder->reject($e);
+            }
         },
-        function ($reason) use ($generator) {
-            $nextYield = $generator->throw(exception_for($reason));
-            // The throw was caught, so keep iterating on the coroutine
-            return __next_coroutine($nextYield, $generator);
+        function ($reason) use ($generator, $state) {
+            unset($state->currentPromise);
+
+            try {
+                $nextYield = $generator->throw(exception_for($reason));
+                // The throw was caught, so keep iterating on the coroutine
+                __next_coroutine($nextYield, $generator, $state);
+            } catch (\Throwable $e) {
+                $state->resultPlaceholder->reject($e);
+            } catch (\Exception $e) {
+                $state->resultPlaceholder->reject($e);
+            }
         }
     );
 }

--- a/tests/CoroutineTest.php
+++ b/tests/CoroutineTest.php
@@ -1,0 +1,65 @@
+<?php
+namespace GuzzleHttp\Promise\Tests;
+
+use GuzzleHttp\Promise\Coroutine;
+use GuzzleHttp\Promise\PromiseInterface;
+use PHPUnit_Framework_TestCase;
+use ReflectionClass;
+
+class CoroutineTest extends PHPUnit_Framework_TestCase
+{
+    /**
+     * @dataProvider promiseInterfaceMethodProvider
+     *
+     * @param string $method
+     * @param array $args
+     */
+    public function testShouldProxyPromiseMethodsToResultPromise($method, $args = [])
+    {
+        $coroutine = new Coroutine(function () { yield 0; });
+        $mockPromise = $this->getMockForAbstractClass(PromiseInterface::class);
+        call_user_func_array([$mockPromise->expects($this->once())->method($method), 'with'], $args);
+
+        $resultPromiseProp = (new ReflectionClass(Coroutine::class))->getProperty('result');
+        $resultPromiseProp->setAccessible(true);
+        $resultPromiseProp->setValue($coroutine, $mockPromise);
+
+        call_user_func_array([$coroutine, $method], $args);
+    }
+
+    public function promiseInterfaceMethodProvider()
+    {
+        return [
+            ['then', [null, null]],
+            ['otherwise', [function () {}]],
+            ['wait', [true]],
+            ['getState', []],
+            ['resolve', [null]],
+            ['reject', [null]],
+        ];
+    }
+
+    public function testShouldCancelResultPromiseAndOutsideCurrentPromise()
+    {
+        $coroutine = new Coroutine(function () { yield 0; });
+
+        $mockPromises = [
+            'result' => $this->getMockForAbstractClass(PromiseInterface::class),
+            'currentPromise' => $this->getMockForAbstractClass(PromiseInterface::class),
+        ];
+        foreach ($mockPromises as $propName => $mockPromise) {
+            /**
+             * @var $mockPromise \PHPUnit_Framework_MockObject_MockObject
+             */
+            $mockPromise->expects($this->once())
+                ->method('cancel')
+                ->with();
+
+            $promiseProp = (new ReflectionClass(Coroutine::class))->getProperty($propName);
+            $promiseProp->setAccessible(true);
+            $promiseProp->setValue($coroutine, $mockPromise);
+        }
+
+        $coroutine->cancel();
+    }
+}


### PR DESCRIPTION
Picking up #35 where @joshdifabio left off. Running through the code sample provided in that PR without this change on PHP7 causes memory usage to grow until PHP segfaults. With this change, memory holds at 6MB while running the entire coroutine.

One potential issue with this approach is the use of `wait`.