### PR TITLE
Add gitattributes to exclude files and folders from exports

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+/tests export-ignore
+.gitattributes export-ignore
+.gitignore export-ignore
+.travis.yml
+phpunit.xml.dist

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,5 @@
 /tests export-ignore
 .gitattributes export-ignore
 .gitignore export-ignore
-.travis.yml
-phpunit.xml.dist
+.travis.yml export-ignore
+phpunit.xml.dist export-ignore


### PR DESCRIPTION
Added `.gitattributes` to exclude the tests folder on export - e.g. when pulled in via composer.

I've also included the following files which are also not required:

`.gitattributes`, `.gitignore`, `.travis.yml`, `phpunit.xml.dist`