### PR TITLE
Extended coroutines

### DIFF
--- a/src/CoroutineInvocation.php
+++ b/src/CoroutineInvocation.php
@@ -1,0 +1,137 @@
+<?php
+namespace GuzzleHttp\Promise;
+
+use Exception;
+use Generator;
+use Throwable;
+
+/**
+ * @internal
+ */
+final class CoroutineInvocation implements PromiseInterface
+{
+    /**
+     * @var PromiseInterface|null
+     */
+    private $currentPromise;
+
+    /**
+     * @var Generator
+     */
+    private $generator;
+
+    /**
+     * @var Promise
+     */
+    private $result;
+
+    public function __construct(Generator $generator)
+    {
+        $this->generator = $generator;
+        $this->result = new Promise(function () {
+            while (isset($this->currentPromise)) {
+                $this->currentPromise->wait();
+            }
+        });
+        $this->nextCoroutine($this->generator->current());
+    }
+
+    public function then(
+        callable $onFulfilled = null,
+        callable $onRejected = null
+    ) {
+        return $this->result->then($onFulfilled, $onRejected);
+    }
+
+    public function otherwise(callable $onRejected)
+    {
+        return $this->result->otherwise($onRejected);
+    }
+
+    public function wait($unwrap = true)
+    {
+        return $this->result->wait($unwrap);
+    }
+
+    public function getState()
+    {
+        return $this->result->getState();
+    }
+
+    public function resolve($value)
+    {
+        $this->result->resolve($value);
+    }
+
+    public function reject($reason)
+    {
+        $this->result->reject($reason);
+    }
+
+    public function cancel()
+    {
+        $this->currentPromise->cancel();
+        $this->result->cancel();
+    }
+
+    private function promiseFor($yielded)
+    {
+        if (is_object($yielded) && ($yielded instanceof Generator)) {
+            // Threat the value like an already running coroutine.
+            $yielded = coroutine_invocation($yielded);
+        } elseif (is_array($yielded)) {
+            $promises = [];
+            foreach ($yielded as $key => $item) {
+                $promises[$key] = $this->promiseFor($item);
+            }
+
+            $yielded = all($promises);
+        }
+
+        return promise_for($yielded);
+    }
+
+    private function nextCoroutine($yielded)
+    {
+        $this->currentPromise = $this->promiseFor($yielded)
+            ->then([$this, '_handleSuccess'], [$this, '_handleFailure']);
+    }
+
+    /**
+     * @internal
+     */
+    public function _handleSuccess($value)
+    {
+        unset($this->currentPromise);
+        try {
+            $next = $this->generator->send($value);
+
+            if (!$this->generator->valid() || $next instanceof CoroutineStop) {
+                $this->result->resolve($value);
+            } else {
+                $this->nextCoroutine($next);
+            }
+        } catch (Exception $exception) {
+            $this->result->reject($exception);
+        } catch (Throwable $throwable) {
+            $this->result->reject($throwable);
+        }
+    }
+
+    /**
+     * @internal
+     */
+    public function _handleFailure($reason)
+    {
+        unset($this->currentPromise);
+        try {
+            $nextYield = $this->generator->throw(exception_for($reason));
+            // The throw was caught, so keep iterating on the coroutine
+            $this->nextCoroutine($nextYield);
+        } catch (Exception $exception) {
+            $this->result->reject($exception);
+        } catch (Throwable $throwable) {
+            $this->result->reject($throwable);
+        }
+    }
+}

--- a/src/CoroutineStop.php
+++ b/src/CoroutineStop.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace GuzzleHttp\Promise;
+
+/**
+ * Signal to stop the current coroutine. Replacement for "return" statement in PHP < 7.0.
+ */
+final class CoroutineStop
+{
+}

--- a/src/functions.php
+++ b/src/functions.php
@@ -455,3 +455,26 @@ function coroutine(callable $generatorFn)
 {
     return new Coroutine($generatorFn);
 }
+
+/**
+ * @param callable $generatorFn
+ *
+ * @return callable
+ */
+function coroutine_fn(callable $generatorFn)
+{
+    return function (...$args) use ($generatorFn) {
+        // Proxy arguments to generator too.
+        return new CoroutineInvocation($generatorFn(...$args));
+    };
+}
+
+/**
+ * @param \Generator $generator
+ *
+ * @return PromiseInterface
+ */
+function coroutine_invocation(\Generator $generator)
+{
+    return new CoroutineInvocation($generator);
+}


### PR DESCRIPTION
I would like to introduce some additional functionality that is very useful, IMO, when you use coroutines a lot.

### `coroutine_fn()` and `coroutine_invocation()`

Sometimes you want to prepare a coroutine, transform a function that returns a generator to a function that returns a coroutine. `coroutine_fn()` to the rescue.

And another case: you already have a generator and want to use it as a coroutine — `coroutine_invocation()`.

This change requires `Coroutine` class change, BTW.

### Yielding a generator

It's convenient when you have more that one coroutine that you want to use in a nested way

``` php
function getEmail($client, $url)
{
    $response = yield $client->getAsync($url);
    $data = json_decode((string) $response->getBody(), true);
    yield $data['email'];
}

function findUsersByEmail($client, $email)
{
    // Another coroutine with async requests.
}

coroutine(function() {
    $client = new Client();
    $email = yield getEmail($client, '...');
    $users = yield findUsersByEmail($email);
    // Do something with the result.
});
```

With current implementation each call must be wrapped in `coroutine()`. IMO, it's annoying when you have many calls like this.

### Simplified `all()` for coroutines

Sometimes it's useful to group coroutines to a group and wait for the results. Something like this.

``` php
function resolveDomainName($name, React\Dns\Resolver\Resolver $resolver)
{
    try {
        $ip = yield $resolver->resolve($name);
    } catch (Exception $e) {
        yield 'Not found';
    }
}

$results = yield all([
    'yandex.ru' => coroutine_invocation(resolveDomainName('yandex.ru', $resolver)),
    'php.net' => coroutine_invocation(resolveDomainName('php.net', $resolver)),
    'google.com' => coroutine_invocation(resolveDomainName('google.com', $resolver)),
];
```

It's possible, but requires some obvious (in comparison with sync version) coding. IMO, specially for `all()` combinator we can support more expressive option using standard arrays:

``` php
$results = yield [
    'yandex.ru' => resolveDomainName('yandex.ru', $resolver),
    'php.net' => resolveDomainName('php.net', $resolver),
    'google.com' => resolveDomainName('google.com', $resolver),
];
```

It works in combination with the previous change (generator support).

### PHP 7 generator's `return` emulation

It's easy to exit from a generator with `return` in PHP 7, but it's not available in earlier versions. I think we can simply use `yield new CoroutineStop;` for that purpose (as in AmPHP, icicle and other coroutines implementations).