### PR TITLE
Fix wait() foreign promise compatibility

### DIFF
--- a/src/Promise.php
+++ b/src/Promise.php
@@ -263,10 +263,17 @@ class Promise implements PromiseInterface
         $this->waitList = null;
 
         foreach ($waitList as $result) {
-            $result->waitIfPending();
-            while ($result->result instanceof Promise) {
-                $result = $result->result;
+            while (true) {
                 $result->waitIfPending();
+
+                if ($result->result instanceof Promise) {
+                    $result = $result->result;
+                } else {
+                    if ($result->result instanceof PromiseInterface) {
+                        $result->result->wait(false);
+                    }
+                    break;
+                }
             }
         }
     }

--- a/tests/CoroutineTest.php
+++ b/tests/CoroutineTest.php
@@ -2,6 +2,7 @@
 namespace GuzzleHttp\Promise\Tests;
 
 use GuzzleHttp\Promise\Coroutine;
+use GuzzleHttp\Promise\Promise;
 use GuzzleHttp\Promise\PromiseInterface;
 use PHPUnit_Framework_TestCase;
 use ReflectionClass;
@@ -61,5 +62,20 @@ class CoroutineTest extends PHPUnit_Framework_TestCase
         }
 
         $coroutine->cancel();
+    }
+
+    public function testWaitShouldResolveChainedCoroutines()
+    {
+        $promisor = function () {
+            return \GuzzleHttp\Promise\coroutine(function () {
+                yield $promise = new Promise(function () use (&$promise) {
+                    $promise->resolve(1);
+                });
+            });
+        };
+
+        $promise = $promisor()->then($promisor)->then($promisor);
+
+        $this->assertSame(1, $promise->wait());
     }
 }


### PR DESCRIPTION
`Promise\wait()` appears to be incompatible with other `PromiseInterface` implementations. This PR addresses the issue and includes a test which fails in v1.3.0 but which passes with the proposed changes. This PR should address #54 and aws/aws-sdk-php#1125.