### PR TITLE
Promise resolution & add a recursive option to all() function

### DIFF
--- a/src/Promise.php
+++ b/src/Promise.php
@@ -243,7 +243,7 @@ class Promise implements PromiseInterface
         try {
             $wfn = $this->waitFn;
             $this->waitFn = null;
-            $wfn(true);
+            $wfn($this);
         } catch (\Exception $reason) {
             if ($this->state === self::PENDING) {
                 // The promise has not been resolved yet, so reject the promise

--- a/tests/PromiseTest.php
+++ b/tests/PromiseTest.php
@@ -67,6 +67,12 @@ class PromiseTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('10', $p->wait());
     }
 
+    public function testInvokesWaitFunctionWithInjectedPromise()
+    {
+        $p = new Promise(function (P\PromiseInterface $p) { $p->resolve('10'); });
+        $this->assertEquals('10', $p->wait());
+    }
+
     /**
      * @expectedException \GuzzleHttp\Promise\RejectionException
      */

--- a/tests/functionsTest.php
+++ b/tests/functionsTest.php
@@ -103,6 +103,22 @@ class FunctionsTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(['a', 'b', 'c'], $result);
     }
 
+    public function testPromisesDynamicallyAddedToStack()
+    {
+        $promises = new \ArrayIterator();
+        $promises['a'] = new FulfilledPromise('a');
+        $promises['b'] = $promise = new Promise(function () use (&$promise, &$promises) {
+            $promise->resolve('b');
+            $promises['c'] = $subPromise = new Promise(function () use (&$subPromise) {
+                $subPromise->resolve('c');
+            });
+        });
+        $result = \GuzzleHttp\Promise\all($promises, true)->wait();
+        $this->assertCount(3, $promises);
+        $this->assertCount(3, $result);
+        $this->assertEquals($result['c'], 'c');
+    }
+
     public function testAllThrowsWhenAnyRejected()
     {
         $a = new Promise();


### PR DESCRIPTION
This PR fixes #57 and #46 

For #57 a freshly created promise is injected into its `wait` function for simpler creation / resolution:
```php
use GuzzleHttp\Promise\Promise;
use GuzzleHttp\Promise\PromiseInterface;

$promise = new Promise(function (PromiseInterface $promise) {
    $promise->resolve('The promise has been resolved');
});
```

For #46 the `all()` function, which resolves a stack of promises, has now an option to resolve new promises that were added to the stack during the resolution of the 1st ones.
```php
use GuzzleHttp\Promise\Promise;
use GuzzleHttp\Promise\PromiseInterface;
use function \GuzzleHttp\Promise\all;

$promises = new ArrayIterator();
$promises['Bill'] = new Promise(function (PromiseInterface $promise) use ($promises) {
    $promise->resolve('Clinton');
    $promises['Donald'] = new Promise(function (PromiseInterface $promise) {
        $promise->resolve('Trump');
    });
});

all($promises, true)->then(function ($result) {
    var_dump($result);
})->wait();
```

outputs: 
```php
array (
  "Bill" => "Clinton"
  "Donald" => "Trump"
)
```

Without this only Bill Clinton would have been resolved. 
To avoid BC breaks this option is set to false by default.

**Use case:**
Call an API which have paginated results: for each page, add a new promise to the stack.