### PR TITLE
Fix #57

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,7 +207,7 @@ function provided to a promise constructor is invoked when the `wait` function
 of the promise is called.
 
 ```php
-$promise = new Promise(function () use (&$promise) {
+$promise = new Promise(function (PromiseInterface $promise) {
     $promise->resolve('foo');
 });
 
@@ -219,7 +219,7 @@ If an exception is encountered while invoking the wait function of a promise,
 the promise is rejected with the exception and the exception is thrown.
 
 ```php
-$promise = new Promise(function () use (&$promise) {
+$promise = new Promise(function (PromiseInterface $promise) {
     throw new \Exception('foo');
 });
 
@@ -299,7 +299,7 @@ that is expected to cancel the computation of a promise. It is invoked when the
 use GuzzleHttp\Promise\Promise;
 
 $promise = new Promise(
-    function () use (&$promise) {
+    function ($promise) {
         $promise->resolve('waited');
     },
     function () {

--- a/src/Promise.php
+++ b/src/Promise.php
@@ -243,7 +243,7 @@ class Promise implements PromiseInterface
         try {
             $wfn = $this->waitFn;
             $this->waitFn = null;
-            $wfn(true);
+            $wfn($this);
         } catch (\Exception $reason) {
             if ($this->state === self::PENDING) {
                 // The promise has not been resolved yet, so reject the promise

--- a/tests/PromiseTest.php
+++ b/tests/PromiseTest.php
@@ -67,6 +67,12 @@ class PromiseTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('10', $p->wait());
     }
 
+    public function testInvokesWaitFunctionWithInjectedPromise()
+    {
+        $p = new Promise(function (P\PromiseInterface $p) { $p->resolve('10'); });
+        $this->assertEquals('10', $p->wait());
+    }
+
     /**
      * @expectedException \GuzzleHttp\Promise\RejectionException
      */


### PR DESCRIPTION
A freshly created promise can now be injected into its `wait` function for simpler creation / resolution:
```php
use GuzzleHttp\Promise\Promise;
use GuzzleHttp\Promise\PromiseInterface;

$promise = new Promise(function (PromiseInterface $promise) {
    $promise->resolve('The promise has been resolved');
});
```