### PR TITLE
Fix #46

### DIFF
--- a/tests/functionsTest.php
+++ b/tests/functionsTest.php
@@ -103,6 +103,22 @@ class FunctionsTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(['a', 'b', 'c'], $result);
     }
 
+    public function testPromisesDynamicallyAddedToStack()
+    {
+        $promises = new \ArrayIterator();
+        $promises['a'] = new FulfilledPromise('a');
+        $promises['b'] = $promise = new Promise(function () use (&$promise, &$promises) {
+            $promise->resolve('b');
+            $promises['c'] = $subPromise = new Promise(function () use (&$subPromise) {
+                $subPromise->resolve('c');
+            });
+        });
+        $result = \GuzzleHttp\Promise\all($promises, true)->wait();
+        $this->assertCount(3, $promises);
+        $this->assertCount(3, $result);
+        $this->assertEquals($result['c'], 'c');
+    }
+
     public function testAllThrowsWhenAnyRejected()
     {
         $a = new Promise();

--- a/tests/functionsTest.php
+++ b/tests/functionsTest.php
@@ -106,8 +106,10 @@ class FunctionsTest extends \PHPUnit_Framework_TestCase
     public function testPromisesDynamicallyAddedToStack()
     {
         $promises = new \ArrayIterator();
+        $counter = 0;
         $promises['a'] = new FulfilledPromise('a');
-        $promises['b'] = $promise = new Promise(function () use (&$promise, &$promises) {
+        $promises['b'] = $promise = new Promise(function () use (&$promise, &$promises, &$counter) {
+            $counter++; // Make sure the wait function is called only once
             $promise->resolve('b');
             $promises['c'] = $subPromise = new Promise(function () use (&$subPromise) {
                 $subPromise->resolve('c');
@@ -117,6 +119,7 @@ class FunctionsTest extends \PHPUnit_Framework_TestCase
         $this->assertCount(3, $promises);
         $this->assertCount(3, $result);
         $this->assertEquals($result['c'], 'c');
+        $this->assertSame(1, $counter);
     }
 
     public function testAllThrowsWhenAnyRejected()


### PR DESCRIPTION
The `all()` function, which resolves a stack of promises, has now an option to resolve new promises that were added to the stack during the resolution of the 1st ones.
```php
use GuzzleHttp\Promise\Promise;
use GuzzleHttp\Promise\PromiseInterface;
use function \GuzzleHttp\Promise\all;

$promises = new ArrayIterator();
$promises['Bill'] = new Promise(function (PromiseInterface $promise) use ($promises) {
    $promise->resolve('Clinton');
    $promises['Donald'] = new Promise(function (PromiseInterface $promise) {
        $promise->resolve('Trump');
    });
});

all($promises, true)->then(function ($result) {
    var_dump($result);
})->wait();
```

outputs: 
```php
array (
  "Bill" => "Clinton"
  "Donald" => "Trump"
)
```

Without this only Bill Clinton would have been resolved. 
To avoid BC breaks this option is set to false by default.

**Use case:**
Call an API which have paginated results: for each page, add a new promise to the stack.