### PR TITLE
Fix promise handling for Iterators of non-unique keys

### DIFF
--- a/src/EachPromise.php
+++ b/src/EachPromise.php
@@ -151,21 +151,27 @@ class EachPromise implements PromisorInterface
         }
 
         $promise = promise_for($this->iterable->current());
-        $idx = $this->iterable->key();
+        $key = $this->iterable->key();
+
+        // Iterable keys may not be unique, so we add the promises at the end
+        // of the pending array and retrieve the array index being used
+        $this->pending[] = null;
+        end($this->pending);
+        $idx = key($this->pending);
 
         $this->pending[$idx] = $promise->then(
-            function ($value) use ($idx) {
+            function ($value) use ($idx, $key) {
                 if ($this->onFulfilled) {
                     call_user_func(
-                        $this->onFulfilled, $value, $idx, $this->aggregate
+                        $this->onFulfilled, $value, $key, $this->aggregate
                     );
                 }
                 $this->step($idx);
             },
-            function ($reason) use ($idx) {
+            function ($reason) use ($idx, $key) {
                 if ($this->onRejected) {
                     call_user_func(
-                        $this->onRejected, $reason, $idx, $this->aggregate
+                        $this->onRejected, $reason, $key, $this->aggregate
                     );
                 }
                 $this->step($idx);

--- a/tests/EachPromiseTest.php
+++ b/tests/EachPromiseTest.php
@@ -342,4 +342,27 @@ class EachPromiseTest extends \PHPUnit_Framework_TestCase
         $each->promise()->wait();
         $this->assertCount(20, $results);
     }
+
+    public function testIteratorWithSameKey()
+    {
+        $iter = function () {
+            yield 'foo' => 1;
+            yield 'foo' => 2;
+            yield 1 => 3;
+            yield 1 => 4;
+        };
+        $called = 0;
+        $each = new EachPromise($iter(), [
+            'fulfilled' => function ($value, $idx, Promise $aggregate) use (&$called) {
+                $called++;
+                if ($value < 3) {
+                    $this->assertSame('foo', $idx);
+                } else {
+                    $this->assertSame(1, $idx);
+                }
+            },
+        ]);
+        $each->promise()->wait();
+        $this->assertSame(4, $called);
+    }
 }

--- a/tests/EachPromiseTest.php
+++ b/tests/EachPromiseTest.php
@@ -346,10 +346,10 @@ class EachPromiseTest extends \PHPUnit_Framework_TestCase
     public function testIteratorWithSameKey()
     {
         $iter = function () {
-            yield 'foo' => 1;
-            yield 'foo' => 2;
-            yield 1 => 3;
-            yield 1 => 4;
+            yield 'foo' => $this->createSelfResolvingPromise(1);
+            yield 'foo' => $this->createSelfResolvingPromise(2);
+            yield 1 => $this->createSelfResolvingPromise(3);
+            yield 1 => $this->createSelfResolvingPromise(4);
         };
         $called = 0;
         $each = new EachPromise($iter(), [


### PR DESCRIPTION
The keys of iterators may not be unique, e.g. using a Generator that `yield 'foo' => 'bar'; yield 'foo' => 'baz'`.

This currently failed because the pending array would just overwrite each one. This resulted in missing Guzzle requests in our case.