### PR TITLE
Test cleanup

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,13 +14,18 @@
         "php": ">=5.5.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^4.0"
+        "phpunit/phpunit": "^4.8.36"
     },
     "autoload": {
         "psr-4": {
             "GuzzleHttp\\Promise\\": "src/"
         },
         "files": ["src/functions_include.php"]
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "GuzzleHttp\\Promise\\Tests\\": "tests/"
+        }
     },
     "scripts": {
         "test": "vendor/bin/phpunit",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit colors="true" bootstrap="tests/bootstrap.php">
+<phpunit colors="true" bootstrap="vendor/autoload.php">
     <testsuites>
         <testsuite name="GuzzleHttp Promise Test Suite">
             <directory>tests/</directory>

--- a/src/EachPromise.php
+++ b/src/EachPromise.php
@@ -91,11 +91,6 @@ class EachPromise implements PromisorInterface
         $this->mutex = false;
         $this->aggregate = new Promise(function () {
             reset($this->pending);
-            if (empty($this->pending) && !$this->iterable->valid()) {
-                $this->aggregate->resolve(null);
-                return;
-            }
-
             // Consume a potentially fluctuating list of promises while
             // ensuring that indexes are maintained (precluding array_shift).
             while ($promise = current($this->pending)) {

--- a/tests/AggregateExceptionTest.php
+++ b/tests/AggregateExceptionTest.php
@@ -2,8 +2,9 @@
 namespace GuzzleHttp\Promise\Tests;
 
 use GuzzleHttp\Promise\AggregateException;
+use PHPUnit\Framework\TestCase;
 
-class AggregateExceptionTest extends \PHPUnit_Framework_TestCase
+class AggregateExceptionTest extends TestCase
 {
     public function testHasReason()
     {

--- a/tests/CoroutineTest.php
+++ b/tests/CoroutineTest.php
@@ -4,10 +4,10 @@ namespace GuzzleHttp\Promise\Tests;
 use GuzzleHttp\Promise\Coroutine;
 use GuzzleHttp\Promise\Promise;
 use GuzzleHttp\Promise\PromiseInterface;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use ReflectionClass;
 
-class CoroutineTest extends PHPUnit_Framework_TestCase
+class CoroutineTest extends TestCase
 {
     /**
      * @dataProvider promiseInterfaceMethodProvider

--- a/tests/EachPromiseTest.php
+++ b/tests/EachPromiseTest.php
@@ -25,7 +25,7 @@ class EachPromiseTest extends TestCase
         $promises = [];
         $each = new EachPromise($promises);
         $p = $each->promise();
-        P\queue()->run();
+        $this->assertNull($p->wait());
         $this->assertEquals(PromiseInterface::FULFILLED, $p->getState());
     }
 
@@ -168,12 +168,6 @@ class EachPromiseTest extends TestCase
     public function testCanBeCancelled()
     {
         $this->markTestIncomplete();
-    }
-
-    public function testFulfillsImmediatelyWhenGivenAnEmptyIterator()
-    {
-        $each = new EachPromise(new \ArrayIterator([]));
-        $result = $each->promise()->wait();
     }
 
     public function testDoesNotBlowStackWithFulfilledPromises()

--- a/tests/EachPromiseTest.php
+++ b/tests/EachPromiseTest.php
@@ -7,11 +7,12 @@ use GuzzleHttp\Promise\Promise;
 use GuzzleHttp\Promise\PromiseInterface;
 use GuzzleHttp\Promise\EachPromise;
 use GuzzleHttp\Promise as P;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @covers GuzzleHttp\Promise\EachPromise
  */
-class EachPromiseTest extends \PHPUnit_Framework_TestCase
+class EachPromiseTest extends TestCase
 {
     public function testReturnsSameInstance()
     {

--- a/tests/EachPromiseTest.php
+++ b/tests/EachPromiseTest.php
@@ -245,7 +245,7 @@ class EachPromiseTest extends TestCase
         $received = null;
         $p->then(null, function ($reason) use (&$e) { $e = $reason; });
         P\queue()->run();
-        $this->assertInstanceOf('Exception', $e);
+        $this->assertInstanceOf(\Exception::class, $e);
         $this->assertEquals('Failure', $e->getMessage());
     }
 

--- a/tests/FulfilledPromiseTest.php
+++ b/tests/FulfilledPromiseTest.php
@@ -3,11 +3,12 @@ namespace GuzzleHttp\Tests\Promise;
 
 use GuzzleHttp\Promise\Promise;
 use GuzzleHttp\Promise\FulfilledPromise;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @covers GuzzleHttp\Promise\FulfilledPromise
  */
-class FulfilledPromiseTest extends \PHPUnit_Framework_TestCase
+class FulfilledPromiseTest extends TestCase
 {
     public function testReturnsValueWhenWaitedUpon()
     {

--- a/tests/PromiseTest.php
+++ b/tests/PromiseTest.php
@@ -3,6 +3,7 @@ namespace GuzzleHttp\Promise\Tests;
 
 use GuzzleHttp\Promise\CancellationException;
 use GuzzleHttp\Promise as P;
+use GuzzleHttp\Promise\FulfilledPromise;
 use GuzzleHttp\Promise\Promise;
 use GuzzleHttp\Promise\RejectedPromise;
 use GuzzleHttp\Promise\RejectionException;
@@ -310,7 +311,7 @@ class PromiseTest extends TestCase
         $p->resolve('foo');
         $p2 = $p->then();
         $this->assertNotSame($p, $p2);
-        $this->assertInstanceOf('GuzzleHttp\Promise\FulfilledPromise', $p2);
+        $this->assertInstanceOf(FulfilledPromise::class, $p2);
     }
 
     public function testCreatesPromiseWhenRejectedAfterThen()
@@ -342,7 +343,7 @@ class PromiseTest extends TestCase
         $p->reject('foo');
         $p2 = $p->then();
         $this->assertNotSame($p, $p2);
-        $this->assertInstanceOf('GuzzleHttp\Promise\RejectedPromise', $p2);
+        $this->assertInstanceOf(RejectedPromise::class, $p2);
     }
 
     public function testInvokesWaitFnsForThens()

--- a/tests/PromiseTest.php
+++ b/tests/PromiseTest.php
@@ -6,11 +6,12 @@ use GuzzleHttp\Promise as P;
 use GuzzleHttp\Promise\Promise;
 use GuzzleHttp\Promise\RejectedPromise;
 use GuzzleHttp\Promise\RejectionException;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @covers GuzzleHttp\Promise\Promise
  */
-class PromiseTest extends \PHPUnit_Framework_TestCase
+class PromiseTest extends TestCase
 {
     /**
      * @expectedException \LogicException

--- a/tests/RejectedPromiseTest.php
+++ b/tests/RejectedPromiseTest.php
@@ -3,11 +3,12 @@ namespace GuzzleHttp\Promise\Tests;
 
 use GuzzleHttp\Promise\Promise;
 use GuzzleHttp\Promise\RejectedPromise;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @covers GuzzleHttp\Promise\RejectedPromise
  */
-class RejectedPromiseTest extends \PHPUnit_Framework_TestCase
+class RejectedPromiseTest extends TestCase
 {
     public function testThrowsReasonWhenWaitedUpon()
     {

--- a/tests/RejectionExceptionTest.php
+++ b/tests/RejectionExceptionTest.php
@@ -2,6 +2,7 @@
 namespace GuzzleHttp\Promise\Tests;
 
 use GuzzleHttp\Promise\RejectionException;
+use PHPUnit\Framework\TestCase;
 
 class Thing1
 {
@@ -27,7 +28,7 @@ class Thing2 implements \JsonSerializable
 /**
  * @covers GuzzleHttp\Promise\RejectionException
  */
-class RejectionExceptionTest extends \PHPUnit_Framework_TestCase
+class RejectionExceptionTest extends TestCase
 {
     public function testCanGetReasonFromException()
     {

--- a/tests/TaskQueueTest.php
+++ b/tests/TaskQueueTest.php
@@ -2,8 +2,9 @@
 namespace GuzzleHttp\Promise\Test;
 
 use GuzzleHttp\Promise\TaskQueue;
+use PHPUnit\Framework\TestCase;
 
-class TaskQueueTest extends \PHPUnit_Framework_TestCase
+class TaskQueueTest extends TestCase
 {
     public function testKnowsIfEmpty()
     {

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,4 +1,0 @@
-<?php
-require __DIR__ . '/../vendor/autoload.php';
-require __DIR__ . '/Thennable.php';
-require __DIR__ . '/NotPromiseInstance.php';

--- a/tests/functionsTest.php
+++ b/tests/functionsTest.php
@@ -5,8 +5,9 @@ use GuzzleHttp\Promise as P;
 use GuzzleHttp\Promise\FulfilledPromise;
 use GuzzleHttp\Promise\Promise;
 use GuzzleHttp\Promise\RejectedPromise;
+use PHPUnit\Framework\TestCase;
 
-class FunctionsTest extends \PHPUnit_Framework_TestCase
+class FunctionsTest extends TestCase
 {
     public function testCreatesPromiseForValue()
     {


### PR DESCRIPTION
- use namespaced phpunit classes
- use autoload-dev
- use ::class constant
- remove duplicate logic from #10 and #64 (they fixed the same thing in different ways)
- add test for cancelled eachpromise