### PR TITLE
Include tests in git repository archives

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,5 +3,3 @@
 /.github/         export-ignore
 .gitignore        export-ignore
 /.travis.yml      export-ignore
-/phpunit.xml.dist export-ignore
-/tests/           export-ignore


### PR DESCRIPTION
The Debian/Ubuntu packages use the tests to validate the built packages. In order to push forward with the PHP 7.2 release in Ubuntu 18.04, we're going to remove the tests from the `php-guzzlehttp-promises` package. I'd like that change to be temporary, though.

If this PR is merged, the tests could be added back to the packaging process to produce better, more trustworthy packages.