### PR TITLE
Grammar Fix of Inline Comment

### DIFF
--- a/src/Promise.php
+++ b/src/Promise.php
@@ -224,7 +224,7 @@ class Promise implements PromiseInterface
         } elseif ($this->waitList) {
             $this->invokeWaitList();
         } else {
-            // If there's not wait function, then reject the promise.
+            // If there's no wait function, then reject the promise.
             $this->reject('Cannot wait on a promise that has '
                 . 'no internal wait function. You must provide a wait '
                 . 'function when constructing the promise to be able to '


### PR DESCRIPTION
This could go either way, `If there's not a wait function` or `If there's no wait function`. I felt the second read better.