### PR TITLE
Fixed pthreads bug: "The promise was rejected"

### DIFF
--- a/src/Promise.php
+++ b/src/Promise.php
@@ -23,6 +23,8 @@ class Promise implements PromiseInterface
         callable $waitFn = null,
         callable $cancelFn = null
     ) {
+        $this->state = self::PENDING;
+        $this->handlers = [];
         $this->waitFn = $waitFn;
         $this->cancelFn = $cancelFn;
     }


### PR DESCRIPTION
As far as I can quickly test, this minor change fixes this issue: https://github.com/guzzle/guzzle/issues/2066

Beyond that the guzzle library appears to work just fine within a pthreads environment :)