### PR TITLE
Param type fix for inspect_all()

### DIFF
--- a/src/Utils.php
+++ b/src/Utils.php
@@ -118,7 +118,7 @@ final class Utils
      * order the promises were provided). An exception is thrown if any of the
      * promises are rejected.
      *
-     * @param mixed $promises Iterable of PromiseInterface objects to wait on.
+     * @param iterable<PromiseInterface> $promises Iterable of PromiseInterface objects to wait on.
      *
      * @return array
      *

--- a/src/functions.php
+++ b/src/functions.php
@@ -145,7 +145,7 @@ function inspect_all($promises)
  * the promises were provided). An exception is thrown if any of the promises
  * are rejected.
  *
- * @param PromiseInterface[] $promises Iterable of PromiseInterface objects to wait on.
+ * @param iterable<PromiseInterface> $promises Iterable of PromiseInterface objects to wait on.
  *
  * @return array
  *

--- a/src/functions.php
+++ b/src/functions.php
@@ -145,7 +145,7 @@ function inspect_all($promises)
  * the promises were provided). An exception is thrown if any of the promises
  * are rejected.
  *
- * @param mixed $promises Iterable of PromiseInterface objects to wait on.
+ * @param PromiseInterface[] $promises Iterable of PromiseInterface objects to wait on.
  *
  * @return array
  *


### PR DESCRIPTION
`inspect_all()` simply goes over an iterable param and passes values to `inspect()` which accepts only `PromiseInterface` instances.