### PR TITLE
Add explicit object checks before calling method_exists()

### DIFF
--- a/src/FulfilledPromise.php
+++ b/src/FulfilledPromise.php
@@ -13,7 +13,7 @@ class FulfilledPromise implements PromiseInterface
 
     public function __construct($value)
     {
-        if (method_exists($value, 'then')) {
+        if (is_object($value) && method_exists($value, 'then')) {
             throw new \InvalidArgumentException(
                 'You cannot create a FulfilledPromise with a promise.');
         }

--- a/src/Promise.php
+++ b/src/Promise.php
@@ -148,7 +148,7 @@ class Promise implements PromiseInterface
 
         // If the value was not a settled promise or a thenable, then resolve
         // it in the task queue using the correct ID.
-        if (!method_exists($value, 'then')) {
+        if (!is_object($value) || !method_exists($value, 'then')) {
             $id = $state === self::FULFILLED ? 1 : 2;
             // It's a success, so resolve the handlers in the queue.
             queue()->add(static function () use ($id, $value, $handlers) {

--- a/src/RejectedPromise.php
+++ b/src/RejectedPromise.php
@@ -13,7 +13,7 @@ class RejectedPromise implements PromiseInterface
 
     public function __construct($reason)
     {
-        if (method_exists($reason, 'then')) {
+        if (is_object($reason) && method_exists($reason, 'then')) {
             throw new \InvalidArgumentException(
                 'You cannot create a RejectedPromise with a promise.');
         }

--- a/src/functions.php
+++ b/src/functions.php
@@ -70,7 +70,7 @@ function promise_for($value)
     }
 
     // Return a Guzzle promise that shadows the given promise.
-    if (method_exists($value, 'then')) {
+    if (is_object($value) && method_exists($value, 'then')) {
         $wfn = method_exists($value, 'wait') ? [$value, 'wait'] : null;
         $cfn = method_exists($value, 'cancel') ? [$value, 'cancel'] : null;
         $promise = new Promise($wfn, $cfn);


### PR DESCRIPTION
I'm sure this doesn't affect many people, but I came across this issue in an older project that uses an autoloader that in some circumstances can call `include()` without checking for file existence (relying on the class file existing somewhere in a directory defined in `include_path`).

Boiling it down, if you register a simple autoloader:

```php
spl_autoload_register(function($class) {
	die($class);
});
```

Then any of the following will trigger the call to `die`:

```php
$promise = new FulfilledPromise('NotAClassName1');
```

```php
$promise = new RejectedPromise('NotAClassName2');
```

```php
$promise = promise_for('NotAClassName3');
```

```php
$promise = new Promise();
$promise->then(function() {}); // A handler must be defined to get to the relevant code
$promise->resolve('NotAClassName4'); // Or reject()
```

This happens because `method_exists` will attempt to load the class if provided with a string that could be a class name. So, this PR adds explicit object checks before calling `method_exists`, as I can't imagine triggering the autoloader being an intended side effect.