### PR TITLE
Change branch alias back to 1.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "1.3-dev"
+            "dev-master": "1.4-dev"
         }
     }
 }


### PR DESCRIPTION
There has actually been a new feature added since 1.3.1, so 1.4.0 will be the next release.