### PR TITLE
Extracted functions to static methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,20 @@
 # CHANGELOG
 
 
+## Upcoming
+
+### Added
+
+- Optional `$recursive` flag to `all`
+- Replaced functions by static methods
+
+### Fixed
+
+- Fix empty `each` processing
+- Fix promise handling for Iterators of non-unique keys
+- Fixed `method_exists` crashes on PHP 8
+
+
 ## 1.3.1 - 2016-12-20
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ for a general introduction to promises.
 - Promises can be cancelled.
 - Works with any object that has a `then` function.
 - C# style async/await coroutine promises using
-  `GuzzleHttp\Promise\coroutine()`.
+  `GuzzleHttp\Promise\Coroutine::of()`.
 
 
 # Quick start
@@ -150,7 +150,7 @@ use GuzzleHttp\Promise\Promise;
 
 $promise = new Promise();
 $promise->then(null, function ($reason) {
-    throw new \Exception($reason);
+    throw new Exception($reason);
 })->then(null, function ($reason) {
     assert($reason->getMessage() === 'Error!');
 });
@@ -220,7 +220,7 @@ the promise is rejected with the exception and the exception is thrown.
 
 ```php
 $promise = new Promise(function () use (&$promise) {
-    throw new \Exception('foo');
+    throw new Exception('foo');
 });
 
 $promise->wait(); // throws the exception.
@@ -397,7 +397,7 @@ $deferred = new React\Promise\Deferred();
 $reactPromise = $deferred->promise();
 
 // Create a Guzzle promise that is fulfilled with a React promise.
-$guzzlePromise = new \GuzzleHttp\Promise\Promise();
+$guzzlePromise = new GuzzleHttp\Promise\Promise();
 $guzzlePromise->then(function ($value) use ($reactPromise) {
     // Do something something with the value...
     // Return the React promise
@@ -424,7 +424,7 @@ instance.
 
 ```php
 // Get the global task queue
-$queue = \GuzzleHttp\Promise\queue();
+$queue = GuzzleHttp\Promise\Utils::queue();
 $queue->run();
 ```
 
@@ -502,3 +502,32 @@ $promise->then(function ($value) { echo $value; });
 $promise->resolve('foo');
 // prints "foo"
 ```
+
+
+## Upgrading from Function API
+
+A static API was first introduced in 1.4.0, in order to mitigate problems with functions conflicting between global and local copies of the package. The function API will be removed in 2.0.0. A migration table has been provided here for your convenience:
+
+| Original Function | Replacement Method |
+|----------------|----------------|
+| `queue` | `Utils::queue` |
+| `task` | `Utils::task` |
+| `promise_for` | `Create::promiseFor` |
+| `rejection_for` | `Create::rejectionFor` |
+| `exception_for` | `Create::exceptionFor` |
+| `iter_for` | `Create::iterFor` |
+| `inspect` | `Utils::inspect` |
+| `inspect_all` | `Utils::inspectAll` |
+| `unwrap` | `Utils::unwrap` |
+| `all` | `Utils::all` |
+| `some` | `Utils::some` |
+| `any` | `Utils::any` |
+| `settle` | `Utils::settle` |
+| `each` | `Each::of` |
+| `each_limit` | `Each::ofLimit` |
+| `each_limit_all` | `Each::ofLimitAll` |
+| `!is_fulfilled` | `Is::pending` |
+| `is_fulfilled` | `Is::fulfilled` |
+| `is_rejected` | `Is::rejected` |
+| `is_settled` | `Is::settled` |
+| `coroutine` | `Coroutine::of` |

--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "1.3-dev"
+            "dev-master": "1.4-dev"
         }
     }
 }

--- a/src/AggregateException.php
+++ b/src/AggregateException.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace GuzzleHttp\Promise;
 
 /**

--- a/src/CancellationException.php
+++ b/src/CancellationException.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace GuzzleHttp\Promise;
 
 /**

--- a/src/Coroutine.php
+++ b/src/Coroutine.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace GuzzleHttp\Promise;
 
 use Exception;
@@ -9,7 +10,7 @@ use Throwable;
  * Creates a promise that is resolved using a generator that yields values or
  * promises (somewhat similar to C#'s async keyword).
  *
- * When called, the coroutine function will start an instance of the generator
+ * When called, the Coroutine::of method will start an instance of the generator
  * and returns a promise that is fulfilled with its final yielded value.
  *
  * Control is returned back to the generator when the yielded promise settles.
@@ -22,7 +23,7 @@ use Throwable;
  *         return new Promise\FulfilledPromise($value);
  *     }
  *
- *     $promise = Promise\coroutine(function () {
+ *     $promise = Promise\Coroutine::of(function () {
  *         $value = (yield createPromise('a'));
  *         try {
  *             $value = (yield createPromise($value . 'b'));
@@ -74,6 +75,16 @@ final class Coroutine implements PromiseInterface
         }
     }
 
+    /**
+     * Create a new coroutine.
+     *
+     * @return self
+     */
+    public static function of(callable $generatorFn)
+    {
+        return new self($generatorFn);
+    }
+
     public function then(
         callable $onFulfilled = null,
         callable $onRejected = null
@@ -114,7 +125,7 @@ final class Coroutine implements PromiseInterface
 
     private function nextCoroutine($yielded)
     {
-        $this->currentPromise = promise_for($yielded)
+        $this->currentPromise = Create::promiseFor($yielded)
             ->then([$this, '_handleSuccess'], [$this, '_handleFailure']);
     }
 
@@ -145,7 +156,7 @@ final class Coroutine implements PromiseInterface
     {
         unset($this->currentPromise);
         try {
-            $nextYield = $this->generator->throw(exception_for($reason));
+            $nextYield = $this->generator->throw(Create::exceptionFor($reason));
             // The throw was caught, so keep iterating on the coroutine
             $this->nextCoroutine($nextYield);
         } catch (Exception $exception) {

--- a/src/Create.php
+++ b/src/Create.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace GuzzleHttp\Promise;
+
+final class Create
+{
+    /**
+     * Creates a promise for a value if the value is not a promise.
+     *
+     * @param mixed $value Promise or value.
+     *
+     * @return PromiseInterface
+     */
+    public static function promiseFor($value)
+    {
+        if ($value instanceof PromiseInterface) {
+            return $value;
+        }
+
+        // Return a Guzzle promise that shadows the given promise.
+        if (is_object($value) && method_exists($value, 'then')) {
+            $wfn = method_exists($value, 'wait') ? [$value, 'wait'] : null;
+            $cfn = method_exists($value, 'cancel') ? [$value, 'cancel'] : null;
+            $promise = new Promise($wfn, $cfn);
+            $value->then([$promise, 'resolve'], [$promise, 'reject']);
+            return $promise;
+        }
+
+        return new FulfilledPromise($value);
+    }
+
+    /**
+     * Creates a rejected promise for a reason if the reason is not a promise.
+     * If the provided reason is a promise, then it is returned as-is.
+     *
+     * @param mixed $reason Promise or reason.
+     *
+     * @return PromiseInterface
+     */
+    public static function rejectionFor($reason)
+    {
+        if ($reason instanceof PromiseInterface) {
+            return $reason;
+        }
+
+        return new RejectedPromise($reason);
+    }
+
+    /**
+     * Create an exception for a rejected promise value.
+     *
+     * @param mixed $reason
+     *
+     * @return \Exception|\Throwable
+     */
+    public static function exceptionFor($reason)
+    {
+        if ($reason instanceof \Exception || $reason instanceof \Throwable) {
+            return $reason;
+        }
+
+        return new RejectionException($reason);
+    }
+
+    /**
+     * Returns an iterator for the given value.
+     *
+     * @param mixed $value
+     *
+     * @return \Iterator
+     */
+    public static function iterFor($value)
+    {
+        if ($value instanceof \Iterator) {
+            return $value;
+        }
+
+        if (is_array($value)) {
+            return new \ArrayIterator($value);
+        }
+
+        return new \ArrayIterator([$value]);
+    }
+}

--- a/src/Each.php
+++ b/src/Each.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace GuzzleHttp\Promise;
+
+final class Each
+{
+    /**
+     * Given an iterator that yields promises or values, returns a promise that
+     * is fulfilled with a null value when the iterator has been consumed or
+     * the aggregate promise has been fulfilled or rejected.
+     *
+     * $onFulfilled is a function that accepts the fulfilled value, iterator
+     * index, and the aggregate promise. The callback can invoke any necessary
+     * side effects and choose to resolve or reject the aggregate if needed.
+     *
+     * $onRejected is a function that accepts the rejection reason, iterator
+     * index, and the aggregate promise. The callback can invoke any necessary
+     * side effects and choose to resolve or reject the aggregate if needed.
+     *
+     * @param mixed    $iterable    Iterator or array to iterate over.
+     * @param callable $onFulfilled
+     * @param callable $onRejected
+     *
+     * @return PromiseInterface
+     */
+    public static function of(
+        $iterable,
+        callable $onFulfilled = null,
+        callable $onRejected = null
+    ) {
+        return (new EachPromise($iterable, [
+            'fulfilled' => $onFulfilled,
+            'rejected'  => $onRejected
+        ]))->promise();
+    }
+
+    /**
+     * Like of, but only allows a certain number of outstanding promises at any
+     * given time.
+     *
+     * $concurrency may be an integer or a function that accepts the number of
+     * pending promises and returns a numeric concurrency limit value to allow
+     * for dynamic a concurrency size.
+     *
+     * @param mixed        $iterable
+     * @param int|callable $concurrency
+     * @param callable     $onFulfilled
+     * @param callable     $onRejected
+     *
+     * @return PromiseInterface
+     */
+    public static function ofLimit(
+        $iterable,
+        $concurrency,
+        callable $onFulfilled = null,
+        callable $onRejected = null
+    ) {
+        return (new EachPromise($iterable, [
+            'fulfilled'   => $onFulfilled,
+            'rejected'    => $onRejected,
+            'concurrency' => $concurrency
+        ]))->promise();
+    }
+
+    /**
+     * Like limit, but ensures that no promise in the given $iterable argument
+     * is rejected. If any promise is rejected, then the aggregate promise is
+     * rejected with the encountered rejection.
+     *
+     * @param mixed        $iterable
+     * @param int|callable $concurrency
+     * @param callable     $onFulfilled
+     *
+     * @return PromiseInterface
+     */
+    public static function ofLimitAll(
+        $iterable,
+        $concurrency,
+        callable $onFulfilled = null
+    ) {
+        return each_limit(
+            $iterable,
+            $concurrency,
+            $onFulfilled,
+            function ($reason, $idx, PromiseInterface $aggregate) {
+                $aggregate->reject($reason);
+            }
+        );
+    }
+}

--- a/src/EachPromise.php
+++ b/src/EachPromise.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace GuzzleHttp\Promise;
 
 /**
@@ -50,7 +51,7 @@ class EachPromise implements PromisorInterface
      */
     public function __construct($iterable, array $config = [])
     {
-        $this->iterable = iter_for($iterable);
+        $this->iterable = Create::iterFor($iterable);
 
         if (isset($config['concurrency'])) {
             $this->concurrency = $config['concurrency'];
@@ -96,7 +97,7 @@ class EachPromise implements PromisorInterface
             while ($promise = current($this->pending)) {
                 next($this->pending);
                 $promise->wait();
-                if ($this->aggregate->getState() !== PromiseInterface::PENDING) {
+                if (Is::settled($this->aggregate)) {
                     return;
                 }
             }
@@ -145,7 +146,7 @@ class EachPromise implements PromisorInterface
             return false;
         }
 
-        $promise = promise_for($this->iterable->current());
+        $promise = Create::promiseFor($this->iterable->current());
         $key = $this->iterable->key();
 
         // Iterable keys may not be unique, so we add the promises at the end
@@ -204,7 +205,7 @@ class EachPromise implements PromisorInterface
     private function step($idx)
     {
         // If the promise was already resolved, then ignore this step.
-        if ($this->aggregate->getState() !== PromiseInterface::PENDING) {
+        if (Is::settled($this->aggregate)) {
             return;
         }
 

--- a/src/FulfilledPromise.php
+++ b/src/FulfilledPromise.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace GuzzleHttp\Promise;
 
 /**
@@ -30,11 +31,11 @@ class FulfilledPromise implements PromiseInterface
             return $this;
         }
 
-        $queue = queue();
+        $queue = Utils::queue();
         $p = new Promise([$queue, 'run']);
         $value = $this->value;
         $queue->add(static function () use ($p, $value, $onFulfilled) {
-            if ($p->getState() === self::PENDING) {
+            if (Is::pending($p)) {
                 try {
                     $p->resolve($onFulfilled($value));
                 } catch (\Throwable $e) {

--- a/src/Is.php
+++ b/src/Is.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace GuzzleHttp\Promise;
+
+final class Is
+{
+    /**
+     * Returns true if a promise is pending.
+     *
+     * @param PromiseInterface $promise
+     *
+     * @return bool
+     */
+    public static function pending(PromiseInterface $promise)
+    {
+        return $promise->getState() === PromiseInterface::PENDING;
+    }
+
+    /**
+     * Returns true if a promise is fulfilled or rejected.
+     *
+     * @param PromiseInterface $promise
+     *
+     * @return bool
+     */
+    public static function settled(PromiseInterface $promise)
+    {
+        return $promise->getState() !== PromiseInterface::PENDING;
+    }
+
+    /**
+     * Returns true if a promise is fulfilled.
+     *
+     * @param PromiseInterface $promise
+     *
+     * @return bool
+     */
+    public static function fulfilled(PromiseInterface $promise)
+    {
+        return $promise->getState() === PromiseInterface::FULFILLED;
+    }
+
+    /**
+     * Returns true if a promise is rejected.
+     *
+     * @param PromiseInterface $promise
+     *
+     * @return bool
+     */
+    public static function rejected(PromiseInterface $promise)
+    {
+        return $promise->getState() === PromiseInterface::REJECTED;
+    }
+}

--- a/src/Promise.php
+++ b/src/Promise.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace GuzzleHttp\Promise;
 
 /**
@@ -41,13 +42,13 @@ class Promise implements PromiseInterface
 
         // Return a fulfilled promise and immediately invoke any callbacks.
         if ($this->state === self::FULFILLED) {
-            $promise = promise_for($this->result);
+            $promise = Create::promiseFor($this->result);
             return $onFulfilled ? $promise->then($onFulfilled) : $promise;
         }
 
         // It's either cancelled or rejected, so return a rejected promise
         // and immediately invoke any callbacks.
-        $rejection = rejection_for($this->result);
+        $rejection = Create::rejectionFor($this->result);
         return $onRejected ? $rejection->then(null, $onRejected) : $rejection;
     }
 
@@ -68,7 +69,7 @@ class Promise implements PromiseInterface
                 return $this->result;
             }
             // It's rejected so "unwrap" and throw an exception.
-            throw exception_for($this->result);
+            throw Create::exceptionFor($this->result);
         }
     }
 
@@ -146,14 +147,12 @@ class Promise implements PromiseInterface
         if (!is_object($value) || !method_exists($value, 'then')) {
             $id = $state === self::FULFILLED ? 1 : 2;
             // It's a success, so resolve the handlers in the queue.
-            queue()->add(static function () use ($id, $value, $handlers) {
+            Utils::queue()->add(static function () use ($id, $value, $handlers) {
                 foreach ($handlers as $handler) {
                     self::callHandler($id, $value, $handler);
                 }
             });
-        } elseif ($value instanceof Promise
-            && $value->getState() === self::PENDING
-        ) {
+        } elseif ($value instanceof Promise && Is::pending($value)) {
             // We can just merge our handlers onto the next promise.
             $value->handlers = array_merge($value->handlers, $handlers);
         } else {
@@ -189,7 +188,7 @@ class Promise implements PromiseInterface
 
         // The promise may have been cancelled or resolved before placing
         // this thunk in the queue.
-        if ($promise->getState() !== self::PENDING) {
+        if (Is::settled($promise)) {
             return;
         }
 
@@ -226,7 +225,7 @@ class Promise implements PromiseInterface
                 . 'wait on a promise.');
         }
 
-        queue()->run();
+        Utils::queue()->run();
 
         if ($this->state === self::PENDING) {
             $this->reject('Invoking the wait callback did not resolve the promise');

--- a/src/PromiseInterface.php
+++ b/src/PromiseInterface.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace GuzzleHttp\Promise;
 
 /**
@@ -56,6 +57,7 @@ interface PromiseInterface
      * Resolve the promise with the given value.
      *
      * @param mixed $value
+     *
      * @throws \RuntimeException if the promise is already resolved.
      */
     public function resolve($value);
@@ -64,6 +66,7 @@ interface PromiseInterface
      * Reject the promise with the given reason.
      *
      * @param mixed $reason
+     *
      * @throws \RuntimeException if the promise is already resolved.
      */
     public function reject($reason);
@@ -86,6 +89,7 @@ interface PromiseInterface
      * @param bool $unwrap
      *
      * @return mixed
+     *
      * @throws \LogicException if the promise has no wait function or if the
      *                         promise does not settle after waiting.
      */

--- a/src/PromisorInterface.php
+++ b/src/PromisorInterface.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace GuzzleHttp\Promise;
 
 /**

--- a/src/RejectedPromise.php
+++ b/src/RejectedPromise.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace GuzzleHttp\Promise;
 
 /**
@@ -30,11 +31,11 @@ class RejectedPromise implements PromiseInterface
             return $this;
         }
 
-        $queue = queue();
+        $queue = Utils::queue();
         $reason = $this->reason;
         $p = new Promise([$queue, 'run']);
         $queue->add(static function () use ($p, $reason, $onRejected) {
-            if ($p->getState() === self::PENDING) {
+            if (Is::pending($p)) {
                 try {
                     // Return a resolved promise if onRejected does not throw.
                     $p->resolve($onRejected($reason));
@@ -59,7 +60,7 @@ class RejectedPromise implements PromiseInterface
     public function wait($unwrap = true, $defaultDelivery = null)
     {
         if ($unwrap) {
-            throw exception_for($this->reason);
+            throw Create::exceptionFor($this->reason);
         }
     }
 

--- a/src/RejectionException.php
+++ b/src/RejectionException.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace GuzzleHttp\Promise;
 
 /**

--- a/src/TaskQueue.php
+++ b/src/TaskQueue.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace GuzzleHttp\Promise;
 
 /**
@@ -8,7 +9,7 @@ namespace GuzzleHttp\Promise;
  * maintains a constant stack size. You can use the task queue asynchronously
  * by calling the `run()` function of the global task queue in an event loop.
  *
- *     GuzzleHttp\Promise\queue()->run();
+ *     GuzzleHttp\Promise\Utils::queue()->run();
  */
 class TaskQueue implements TaskQueueInterface
 {

--- a/src/TaskQueueInterface.php
+++ b/src/TaskQueueInterface.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace GuzzleHttp\Promise;
 
 interface TaskQueueInterface

--- a/src/Utils.php
+++ b/src/Utils.php
@@ -1,0 +1,274 @@
+<?php
+
+namespace GuzzleHttp\Promise;
+
+final class Utils
+{
+    /**
+     * Get the global task queue used for promise resolution.
+     *
+     * This task queue MUST be run in an event loop in order for promises to be
+     * settled asynchronously. It will be automatically run when synchronously
+     * waiting on a promise.
+     *
+     * <code>
+     * while ($eventLoop->isRunning()) {
+     *     GuzzleHttp\Promise\Utils::queue()->run();
+     * }
+     * </code>
+     *
+     * @param TaskQueueInterface $assign Optionally specify a new queue instance.
+     *
+     * @return TaskQueueInterface
+     */
+    public static function queue(TaskQueueInterface $assign = null)
+    {
+        static $queue;
+
+        if ($assign) {
+            $queue = $assign;
+        } elseif (!$queue) {
+            $queue = new TaskQueue();
+        }
+
+        return $queue;
+    }
+
+    /**
+     * Adds a function to run in the task queue when it is next `run()` and
+     * returns a promise that is fulfilled or rejected with the result.
+     *
+     * @param callable $task Task function to run.
+     *
+     * @return PromiseInterface
+     */
+    public static function task(callable $task)
+    {
+        $queue = self::queue();
+        $promise = new Promise([$queue, 'run']);
+        $queue->add(function () use ($task, $promise) {
+            try {
+                $promise->resolve($task());
+            } catch (\Throwable $e) {
+                $promise->reject($e);
+            } catch (\Exception $e) {
+                $promise->reject($e);
+            }
+        });
+
+        return $promise;
+    }
+
+    /**
+     * Synchronously waits on a promise to resolve and returns an inspection
+     * state array.
+     *
+     * Returns a state associative array containing a "state" key mapping to a
+     * valid promise state. If the state of the promise is "fulfilled", the
+     * array will contain a "value" key mapping to the fulfilled value of the
+     * promise. If the promise is rejected, the array will contain a "reason"
+     * key mapping to the rejection reason of the promise.
+     *
+     * @param PromiseInterface $promise Promise or value.
+     *
+     * @return array
+     */
+    public static function inspect(PromiseInterface $promise)
+    {
+        try {
+            return [
+                'state' => PromiseInterface::FULFILLED,
+                'value' => $promise->wait()
+            ];
+        } catch (RejectionException $e) {
+            return ['state' => PromiseInterface::REJECTED, 'reason' => $e->getReason()];
+        } catch (\Throwable $e) {
+            return ['state' => PromiseInterface::REJECTED, 'reason' => $e];
+        } catch (\Exception $e) {
+            return ['state' => PromiseInterface::REJECTED, 'reason' => $e];
+        }
+    }
+
+    /**
+     * Waits on all of the provided promises, but does not unwrap rejected
+     * promises as thrown exception.
+     *
+     * Returns an array of inspection state arrays.
+     *
+     * @see inspect for the inspection state array format.
+     *
+     * @param PromiseInterface[] $promises Traversable of promises to wait upon.
+     *
+     * @return array
+     */
+    public static function inspectAll($promises)
+    {
+        $results = [];
+        foreach ($promises as $key => $promise) {
+            $results[$key] = inspect($promise);
+        }
+
+        return $results;
+    }
+
+    /**
+     * Waits on all of the provided promises and returns the fulfilled values.
+     *
+     * Returns an array that contains the value of each promise (in the same
+     * order the promises were provided). An exception is thrown if any of the
+     * promises are rejected.
+     *
+     * @param mixed $promises Iterable of PromiseInterface objects to wait on.
+     *
+     * @return array
+     *
+     * @throws \Exception on error
+     * @throws \Throwable on error in PHP >=7
+     */
+    public static function unwrap($promises)
+    {
+        $results = [];
+        foreach ($promises as $key => $promise) {
+            $results[$key] = $promise->wait();
+        }
+
+        return $results;
+    }
+
+    /**
+     * Given an array of promises, return a promise that is fulfilled when all
+     * the items in the array are fulfilled.
+     *
+     * The promise's fulfillment value is an array with fulfillment values at
+     * respective positions to the original array. If any promise in the array
+     * rejects, the returned promise is rejected with the rejection reason.
+     *
+     * @param mixed $promises  Promises or values.
+     * @param bool  $recursive If true, resolves new promises that might have been added to the stack during its own resolution.
+     *
+     * @return PromiseInterface
+     */
+    public static function all($promises, $recursive = false)
+    {
+        $results = [];
+        $promise = Each::of(
+            $promises,
+            function ($value, $idx) use (&$results) {
+                $results[$idx] = $value;
+            },
+            function ($reason, $idx, Promise $aggregate) {
+                $aggregate->reject($reason);
+            }
+        )->then(function () use (&$results) {
+            ksort($results);
+            return $results;
+        });
+
+        if ($recursive) {
+            $promise = $promise->then(function ($results) use ($recursive, &$promises) {
+                foreach ($promises AS $promise) {
+                    if (Is::pending($promise)) {
+                        return self::all($promises, $recursive);
+                    }
+                }
+                return $results;
+            });
+        }
+
+        return $promise;
+    }
+
+    /**
+     * Initiate a competitive race between multiple promises or values (values
+     * will become immediately fulfilled promises).
+     *
+     * When count amount of promises have been fulfilled, the returned promise
+     * is fulfilled with an array that contains the fulfillment values of the
+     * winners in order of resolution.
+     *
+     * This promise is rejected with a {@see AggregateException} if the number
+     * of fulfilled promises is less than the desired $count.
+     *
+     * @param int   $count    Total number of promises.
+     * @param mixed $promises Promises or values.
+     *
+     * @return PromiseInterface
+     */
+    public static function some($count, $promises)
+    {
+        $results = [];
+        $rejections = [];
+
+        return Each::of(
+            $promises,
+            function ($value, $idx, PromiseInterface $p) use (&$results, $count) {
+                if (Is::settled($p)) {
+                    return;
+                }
+                $results[$idx] = $value;
+                if (count($results) >= $count) {
+                    $p->resolve(null);
+                }
+            },
+            function ($reason) use (&$rejections) {
+                $rejections[] = $reason;
+            }
+        )->then(
+            function () use (&$results, &$rejections, $count) {
+                if (count($results) !== $count) {
+                    throw new AggregateException(
+                        'Not enough promises to fulfill count',
+                        $rejections
+                    );
+                }
+                ksort($results);
+                return array_values($results);
+            }
+        );
+    }
+
+    /**
+     * Like some(), with 1 as count. However, if the promise fulfills, the
+     * fulfillment value is not an array of 1 but the value directly.
+     *
+     * @param mixed $promises Promises or values.
+     *
+     * @return PromiseInterface
+     */
+    public static function any($promises)
+    {
+        return self::some(1, $promises)->then(function ($values) {
+            return $values[0];
+        });
+    }
+
+    /**
+     * Returns a promise that is fulfilled when all of the provided promises have
+     * been fulfilled or rejected.
+     *
+     * The returned promise is fulfilled with an array of inspection state arrays.
+     *
+     * @see inspect for the inspection state array format.
+     *
+     * @param mixed $promises Promises or values.
+     *
+     * @return PromiseInterface
+     */
+    public static function settle($promises)
+    {
+        $results = [];
+
+        return Each::of(
+            $promises,
+            function ($value, $idx) use (&$results) {
+                $results[$idx] = ['state' => PromiseInterface::FULFILLED, 'value' => $value];
+            },
+            function ($reason, $idx) use (&$results) {
+                $results[$idx] = ['state' => PromiseInterface::REJECTED, 'reason' => $reason];
+            }
+        )->then(function () use (&$results) {
+            ksort($results);
+            return $results;
+        });
+    }
+}

--- a/src/Utils.php
+++ b/src/Utils.php
@@ -164,7 +164,7 @@ final class Utils
             return $results;
         });
 
-        if ($recursive) {
+        if (true === $recursive) {
             $promise = $promise->then(function ($results) use ($recursive, &$promises) {
                 foreach ($promises AS $promise) {
                     if (Is::pending($promise)) {

--- a/src/functions.php
+++ b/src/functions.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace GuzzleHttp\Promise;
 
 /**
@@ -17,18 +18,12 @@ namespace GuzzleHttp\Promise;
  * @param TaskQueueInterface $assign Optionally specify a new queue instance.
  *
  * @return TaskQueueInterface
+ *
+ * @deprecated queue will be removed in guzzlehttp/promises:2.0. Use Utils::queue instead.
  */
 function queue(TaskQueueInterface $assign = null)
 {
-    static $queue;
-
-    if ($assign) {
-        $queue = $assign;
-    } elseif (!$queue) {
-        $queue = new TaskQueue();
-    }
-
-    return $queue;
+    return Utils::queue($assign);
 }
 
 /**
@@ -38,22 +33,12 @@ function queue(TaskQueueInterface $assign = null)
  * @param callable $task Task function to run.
  *
  * @return PromiseInterface
+ *
+ * @deprecated task will be removed in guzzlehttp/promises:2.0. Use Utils::task instead.
  */
 function task(callable $task)
 {
-    $queue = queue();
-    $promise = new Promise([$queue, 'run']);
-    $queue->add(function () use ($task, $promise) {
-        try {
-            $promise->resolve($task());
-        } catch (\Throwable $e) {
-            $promise->reject($e);
-        } catch (\Exception $e) {
-            $promise->reject($e);
-        }
-    });
-
-    return $promise;
+    return Utils::task($task);
 }
 
 /**
@@ -62,23 +47,12 @@ function task(callable $task)
  * @param mixed $value Promise or value.
  *
  * @return PromiseInterface
+ *
+ * @deprecated promise_for will be removed in guzzlehttp/promises:2.0. Use Create::promiseFor instead.
  */
 function promise_for($value)
 {
-    if ($value instanceof PromiseInterface) {
-        return $value;
-    }
-
-    // Return a Guzzle promise that shadows the given promise.
-    if (is_object($value) && method_exists($value, 'then')) {
-        $wfn = method_exists($value, 'wait') ? [$value, 'wait'] : null;
-        $cfn = method_exists($value, 'cancel') ? [$value, 'cancel'] : null;
-        $promise = new Promise($wfn, $cfn);
-        $value->then([$promise, 'resolve'], [$promise, 'reject']);
-        return $promise;
-    }
-
-    return new FulfilledPromise($value);
+    return Create::promiseFor($value);
 }
 
 /**
@@ -88,14 +62,12 @@ function promise_for($value)
  * @param mixed $reason Promise or reason.
  *
  * @return PromiseInterface
+ *
+ * @deprecated rejection_for will be removed in guzzlehttp/promises:2.0. Use Create::rejectionFor instead.
  */
 function rejection_for($reason)
 {
-    if ($reason instanceof PromiseInterface) {
-        return $reason;
-    }
-
-    return new RejectedPromise($reason);
+    return Create::rejectionFor($reason);
 }
 
 /**
@@ -104,12 +76,12 @@ function rejection_for($reason)
  * @param mixed $reason
  *
  * @return \Exception|\Throwable
+ *
+ * @deprecated exception_for will be removed in guzzlehttp/promises:2.0. Use Create::exceptionFor instead.
  */
 function exception_for($reason)
 {
-    return $reason instanceof \Exception || $reason instanceof \Throwable
-        ? $reason
-        : new RejectionException($reason);
+    return Create::exceptionFor($reason);
 }
 
 /**
@@ -118,16 +90,12 @@ function exception_for($reason)
  * @param mixed $value
  *
  * @return \Iterator
+ *
+ * @deprecated iter_for will be removed in guzzlehttp/promises:2.0. Use Create::iterFor instead.
  */
 function iter_for($value)
 {
-    if ($value instanceof \Iterator) {
-        return $value;
-    } elseif (is_array($value)) {
-        return new \ArrayIterator($value);
-    } else {
-        return new \ArrayIterator([$value]);
-    }
+    return Create::iterFor($value);
 }
 
 /**
@@ -143,21 +111,12 @@ function iter_for($value)
  * @param PromiseInterface $promise Promise or value.
  *
  * @return array
+ *
+ * @deprecated inspect will be removed in guzzlehttp/promises:2.0. Use Utils::inspect instead.
  */
 function inspect(PromiseInterface $promise)
 {
-    try {
-        return [
-            'state' => PromiseInterface::FULFILLED,
-            'value' => $promise->wait()
-        ];
-    } catch (RejectionException $e) {
-        return ['state' => PromiseInterface::REJECTED, 'reason' => $e->getReason()];
-    } catch (\Throwable $e) {
-        return ['state' => PromiseInterface::REJECTED, 'reason' => $e];
-    } catch (\Exception $e) {
-        return ['state' => PromiseInterface::REJECTED, 'reason' => $e];
-    }
+    return Utils::inspect($promise);
 }
 
 /**
@@ -166,19 +125,17 @@ function inspect(PromiseInterface $promise)
  *
  * Returns an array of inspection state arrays.
  *
+ * @see inspect for the inspection state array format.
+ *
  * @param PromiseInterface[] $promises Traversable of promises to wait upon.
  *
  * @return array
- * @see GuzzleHttp\Promise\inspect for the inspection state array format.
+ *
+ * @deprecated inspect will be removed in guzzlehttp/promises:2.0. Use Utils::inspectAll instead.
  */
 function inspect_all($promises)
 {
-    $results = [];
-    foreach ($promises as $key => $promise) {
-        $results[$key] = inspect($promise);
-    }
-
-    return $results;
+    return Utils::inspectAll($promises);
 }
 
 /**
@@ -191,17 +148,15 @@ function inspect_all($promises)
  * @param mixed $promises Iterable of PromiseInterface objects to wait on.
  *
  * @return array
+ *
  * @throws \Exception on error
  * @throws \Throwable on error in PHP >=7
+ *
+ * @deprecated unwrap will be removed in guzzlehttp/promises:2.0. Use Utils::unwrap instead.
  */
 function unwrap($promises)
 {
-    $results = [];
-    foreach ($promises as $key => $promise) {
-        $results[$key] = $promise->wait();
-    }
-
-    return $results;
+    return Utils::unwrap($promises);
 }
 
 /**
@@ -212,39 +167,16 @@ function unwrap($promises)
  * respective positions to the original array. If any promise in the array
  * rejects, the returned promise is rejected with the rejection reason.
  *
- * @param mixed $promises Promises or values.
- * @param bool $recursive - If true, resolves new promises that might have been added to the stack during its own resolution.
+ * @param mixed $promises  Promises or values.
+ * @param bool  $recursive If true, resolves new promises that might have been added to the stack during its own resolution.
  *
  * @return PromiseInterface
+ *
+ * @deprecated all will be removed in guzzlehttp/promises:2.0. Use Utils::all instead.
  */
 function all($promises, $recursive = false)
 {
-    $results = [];
-    $promise = \GuzzleHttp\Promise\each(
-        $promises,
-        function ($value, $idx) use (&$results) {
-            $results[$idx] = $value;
-        },
-        function ($reason, $idx, Promise $aggregate) {
-            $aggregate->reject($reason);
-        }
-    )->then(function () use (&$results) {
-        ksort($results);
-        return $results;
-    });
-
-    if (true === $recursive) {
-        $promise = $promise->then(function ($results) use ($recursive, &$promises) {
-            foreach ($promises AS $promise) {
-                if (\GuzzleHttp\Promise\PromiseInterface::PENDING === $promise->getState()) {
-                    return all($promises, $recursive);
-                }
-            }
-            return $results;
-        });
-    }
-
-    return $promise;
+    return Utils::all($promises, $recursive);
 }
 
 /**
@@ -255,45 +187,19 @@ function all($promises, $recursive = false)
  * fulfilled with an array that contains the fulfillment values of the winners
  * in order of resolution.
  *
- * This promise is rejected with a {@see GuzzleHttp\Promise\AggregateException}
- * if the number of fulfilled promises is less than the desired $count.
+ * This promise is rejected with a {@see AggregateException} if the number of
+ * fulfilled promises is less than the desired $count.
  *
  * @param int   $count    Total number of promises.
  * @param mixed $promises Promises or values.
  *
  * @return PromiseInterface
+ *
+ * @deprecated some will be removed in guzzlehttp/promises:2.0. Use Utils::some instead.
  */
 function some($count, $promises)
 {
-    $results = [];
-    $rejections = [];
-
-    return \GuzzleHttp\Promise\each(
-        $promises,
-        function ($value, $idx, PromiseInterface $p) use (&$results, $count) {
-            if ($p->getState() !== PromiseInterface::PENDING) {
-                return;
-            }
-            $results[$idx] = $value;
-            if (count($results) >= $count) {
-                $p->resolve(null);
-            }
-        },
-        function ($reason) use (&$rejections) {
-            $rejections[] = $reason;
-        }
-    )->then(
-        function () use (&$results, &$rejections, $count) {
-            if (count($results) !== $count) {
-                throw new AggregateException(
-                    'Not enough promises to fulfill count',
-                    $rejections
-                );
-            }
-            ksort($results);
-            return array_values($results);
-        }
-    );
+    return Utils::some($count, $promises);
 }
 
 /**
@@ -303,10 +209,12 @@ function some($count, $promises)
  * @param mixed $promises Promises or values.
  *
  * @return PromiseInterface
+ *
+ * @deprecated any will be removed in guzzlehttp/promises:2.0. Use Utils::any instead.
  */
 function any($promises)
 {
-    return some(1, $promises)->then(function ($values) { return $values[0]; });
+    return Utils::any($promises);
 }
 
 /**
@@ -315,27 +223,17 @@ function any($promises)
  *
  * The returned promise is fulfilled with an array of inspection state arrays.
  *
+ * @see inspect for the inspection state array format.
+ *
  * @param mixed $promises Promises or values.
  *
  * @return PromiseInterface
- * @see GuzzleHttp\Promise\inspect for the inspection state array format.
+ *
+ * @deprecated settle will be removed in guzzlehttp/promises:2.0. Use Utils::settle instead.
  */
 function settle($promises)
 {
-    $results = [];
-
-    return \GuzzleHttp\Promise\each(
-        $promises,
-        function ($value, $idx) use (&$results) {
-            $results[$idx] = ['state' => PromiseInterface::FULFILLED, 'value' => $value];
-        },
-        function ($reason, $idx) use (&$results) {
-            $results[$idx] = ['state' => PromiseInterface::REJECTED, 'reason' => $reason];
-        }
-    )->then(function () use (&$results) {
-        ksort($results);
-        return $results;
-    });
+    return Utils::settle($promises);
 }
 
 /**
@@ -343,29 +241,28 @@ function settle($promises)
  * fulfilled with a null value when the iterator has been consumed or the
  * aggregate promise has been fulfilled or rejected.
  *
- * $onFulfilled is a function that accepts the fulfilled value, iterator
- * index, and the aggregate promise. The callback can invoke any necessary side
- * effects and choose to resolve or reject the aggregate promise if needed.
+ * $onFulfilled is a function that accepts the fulfilled value, iterator index,
+ * and the aggregate promise. The callback can invoke any necessary side
+ * effects and choose to resolve or reject the aggregate if needed.
  *
- * $onRejected is a function that accepts the rejection reason, iterator
- * index, and the aggregate promise. The callback can invoke any necessary side
- * effects and choose to resolve or reject the aggregate promise if needed.
+ * $onRejected is a function that accepts the rejection reason, iterator index,
+ * and the aggregate promise. The callback can invoke any necessary side
+ * effects and choose to resolve or reject the aggregate if needed.
  *
  * @param mixed    $iterable    Iterator or array to iterate over.
  * @param callable $onFulfilled
  * @param callable $onRejected
  *
  * @return PromiseInterface
+ *
+ * @deprecated each will be removed in guzzlehttp/promises:2.0. Use Each::of instead.
  */
 function each(
     $iterable,
     callable $onFulfilled = null,
     callable $onRejected = null
 ) {
-    return (new EachPromise($iterable, [
-        'fulfilled' => $onFulfilled,
-        'rejected'  => $onRejected
-    ]))->promise();
+    return Each::of($iterable, $onFulfilled, $onRejected);
 }
 
 /**
@@ -382,6 +279,8 @@ function each(
  * @param callable     $onRejected
  *
  * @return PromiseInterface
+ *
+ * @deprecated each_limit will be removed in guzzlehttp/promises:2.0. Use Each::ofLimit instead.
  */
 function each_limit(
     $iterable,
@@ -389,11 +288,7 @@ function each_limit(
     callable $onFulfilled = null,
     callable $onRejected = null
 ) {
-    return (new EachPromise($iterable, [
-        'fulfilled'   => $onFulfilled,
-        'rejected'    => $onRejected,
-        'concurrency' => $concurrency
-    ]))->promise();
+    return Each::ofLimit($iterable, $concurrency, $onFulfilled, $onRejected);
 }
 
 /**
@@ -405,21 +300,20 @@ function each_limit(
  * @param int|callable $concurrency
  * @param callable     $onFulfilled
  *
+ * @param mixed        $iterable
+ * @param int|callable $concurrency
+ * @param callable     $onFulfilled
+ *
  * @return PromiseInterface
+ *
+ * @deprecated each_limit_all will be removed in guzzlehttp/promises:2.0. Use Each::ofLimitAll instead.
  */
 function each_limit_all(
     $iterable,
     $concurrency,
     callable $onFulfilled = null
 ) {
-    return each_limit(
-        $iterable,
-        $concurrency,
-        $onFulfilled,
-        function ($reason, $idx, PromiseInterface $aggregate) {
-            $aggregate->reject($reason);
-        }
-    );
+    return Each::ofLimitAll($iterable, $concurrency, $onFulfilled);
 }
 
 /**
@@ -428,10 +322,12 @@ function each_limit_all(
  * @param PromiseInterface $promise
  *
  * @return bool
+ *
+ * @deprecated is_fulfilled will be removed in guzzlehttp/promises:2.0. Use Is::fulfilled instead.
  */
 function is_fulfilled(PromiseInterface $promise)
 {
-    return $promise->getState() === PromiseInterface::FULFILLED;
+    return Is::fulfilled($promise);
 }
 
 /**
@@ -440,10 +336,12 @@ function is_fulfilled(PromiseInterface $promise)
  * @param PromiseInterface $promise
  *
  * @return bool
+ *
+ * @deprecated is_rejected will be removed in guzzlehttp/promises:2.0. Use Is::rejected instead.
  */
 function is_rejected(PromiseInterface $promise)
 {
-    return $promise->getState() === PromiseInterface::REJECTED;
+    return Is::rejected($promise);
 }
 
 /**
@@ -452,20 +350,26 @@ function is_rejected(PromiseInterface $promise)
  * @param PromiseInterface $promise
  *
  * @return bool
+ *
+ * @deprecated is_settled will be removed in guzzlehttp/promises:2.0. Use Is::settled instead.
  */
 function is_settled(PromiseInterface $promise)
 {
-    return $promise->getState() !== PromiseInterface::PENDING;
+    return Is::settled($promise);
 }
 
 /**
+ * Create a new coroutine.
+ *
  * @see Coroutine
  *
  * @param callable $generatorFn
  *
  * @return PromiseInterface
+ *
+ * @deprecated coroutine will be removed in guzzlehttp/promises:2.0. Use Coroutine::of instead.
  */
 function coroutine(callable $generatorFn)
 {
-    return new Coroutine($generatorFn);
+    return Coroutine::of($generatorFn);
 }

--- a/tests/AggregateExceptionTest.php
+++ b/tests/AggregateExceptionTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace GuzzleHttp\Promise\Tests;
 
 use GuzzleHttp\Promise\AggregateException;
@@ -10,6 +11,6 @@ class AggregateExceptionTest extends TestCase
     {
         $e = new AggregateException('foo', ['baz', 'bar']);
         $this->assertContains('foo', $e->getMessage());
-        $this->assertEquals(['baz', 'bar'], $e->getReason());
+        $this->assertSame(['baz', 'bar'], $e->getReason());
     }
 }

--- a/tests/CoroutineTest.php
+++ b/tests/CoroutineTest.php
@@ -1,6 +1,8 @@
 <?php
+
 namespace GuzzleHttp\Promise\Tests;
 
+use GuzzleHttp\Promise as P;
 use GuzzleHttp\Promise\Coroutine;
 use GuzzleHttp\Promise\Promise;
 use GuzzleHttp\Promise\PromiseInterface;
@@ -9,6 +11,12 @@ use ReflectionClass;
 
 class CoroutineTest extends TestCase
 {
+    public function testReturnsCoroutine()
+    {
+        $fn = function () { yield 'foo'; };
+        $this->assertInstanceOf(P\Coroutine::class, P\Coroutine::of($fn));
+    }
+
     /**
      * @dataProvider promiseInterfaceMethodProvider
      *
@@ -67,7 +75,7 @@ class CoroutineTest extends TestCase
     public function testWaitShouldResolveChainedCoroutines()
     {
         $promisor = function () {
-            return \GuzzleHttp\Promise\coroutine(function () {
+            return P\Coroutine::of(function () {
                 yield $promise = new Promise(function () use (&$promise) {
                     $promise->resolve(1);
                 });
@@ -81,13 +89,13 @@ class CoroutineTest extends TestCase
 
     public function testWaitShouldHandleIntermediateErrors()
     {
-        $promise = \GuzzleHttp\Promise\coroutine(function () {
+        $promise = P\Coroutine::of(function () {
             yield $promise = new Promise(function () use (&$promise) {
                 $promise->resolve(1);
             });
         })
         ->then(function () {
-            return \GuzzleHttp\Promise\coroutine(function () {
+            return P\Coroutine::of(function () {
                 yield $promise = new Promise(function () use (&$promise) {
                     $promise->reject(new \Exception);
                 });

--- a/tests/CreateTest.php
+++ b/tests/CreateTest.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace GuzzleHttp\Promise\Tests;
+
+use GuzzleHttp\Promise as P;
+use GuzzleHttp\Promise\FulfilledPromise;
+use GuzzleHttp\Promise\Promise;
+use GuzzleHttp\Promise\PromiseInterface;
+use GuzzleHttp\Promise\RejectedPromise;
+use PHPUnit\Framework\TestCase;
+
+class CreateTest extends TestCase
+{
+    public function testCreatesPromiseForValue()
+    {
+        $p = P\Create::promiseFor('foo');
+        $this->assertInstanceOf(FulfilledPromise::class, $p);
+    }
+
+    public function testReturnsPromiseForPromise()
+    {
+        $p = new Promise();
+        $this->assertSame($p, P\Create::promiseFor($p));
+    }
+
+    public function testReturnsPromiseForThennable()
+    {
+        $p = new Thennable();
+        $wrapped = P\Create::promiseFor($p);
+        $this->assertNotSame($p, $wrapped);
+        $this->assertInstanceOf(PromiseInterface::class, $wrapped);
+        $p->resolve('foo');
+        P\Utils::queue()->run();
+        $this->assertSame('foo', $wrapped->wait());
+    }
+
+    public function testReturnsRejection()
+    {
+        $p = P\Create::rejectionFor('fail');
+        $this->assertInstanceOf(RejectedPromise::class, $p);
+        $this->assertSame('fail', $this->readAttribute($p, 'reason'));
+    }
+
+    public function testReturnsPromisesAsIsInRejectionFor()
+    {
+        $a = new Promise();
+        $b = P\Create::rejectionFor($a);
+        $this->assertSame($a, $b);
+    }
+
+    public function testIterForReturnsIterator()
+    {
+        $iter = new \ArrayIterator();
+        $this->assertSame($iter, P\Create::iterFor($iter));
+    }
+}

--- a/tests/EachTest.php
+++ b/tests/EachTest.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace GuzzleHttp\Promise\Tests;
+
+use GuzzleHttp\Promise as P;
+use GuzzleHttp\Promise\FulfilledPromise;
+use GuzzleHttp\Promise\Promise;
+use GuzzleHttp\Promise\RejectedPromise;
+use PHPUnit\Framework\TestCase;
+
+class EachTest extends TestCase
+{
+    public function testCallsEachLimit()
+    {
+        $p = new Promise();
+        $aggregate = P\Each::ofLimit($p, 2);
+
+        $p->resolve('a');
+        P\Utils::queue()->run();
+        $this->assertTrue(P\Is::fulfilled($aggregate));
+    }
+
+    public function testEachLimitAllRejectsOnFailure()
+    {
+        $p = [new FulfilledPromise('a'), new RejectedPromise('b')];
+        $aggregate = P\Each::ofLimitAll($p, 2);
+
+        P\Utils::queue()->run();
+        $this->assertTrue(P\Is::rejected($aggregate));
+
+        $result = P\Utils::inspect($aggregate);
+        $this->assertSame('b', $result['reason']);
+    }
+}

--- a/tests/FulfilledPromiseTest.php
+++ b/tests/FulfilledPromiseTest.php
@@ -1,6 +1,8 @@
 <?php
+
 namespace GuzzleHttp\Tests\Promise;
 
+use GuzzleHttp\Promise as P;
 use GuzzleHttp\Promise\Promise;
 use GuzzleHttp\Promise\FulfilledPromise;
 use PHPUnit\Framework\TestCase;
@@ -13,16 +15,16 @@ class FulfilledPromiseTest extends TestCase
     public function testReturnsValueWhenWaitedUpon()
     {
         $p = new FulfilledPromise('foo');
-        $this->assertEquals('fulfilled', $p->getState());
-        $this->assertEquals('foo', $p->wait(true));
+        $this->assertTrue(P\Is::fulfilled($p));
+        $this->assertSame('foo', $p->wait(true));
     }
 
     public function testCannotCancel()
     {
         $p = new FulfilledPromise('foo');
-        $this->assertEquals('fulfilled', $p->getState());
+        $this->assertTrue(P\Is::fulfilled($p));
         $p->cancel();
-        $this->assertEquals('foo', $p->wait());
+        $this->assertSame('foo', $p->wait());
     }
 
     /**
@@ -74,8 +76,8 @@ class FulfilledPromiseTest extends TestCase
         $p2 = $p->then($f);
         $this->assertNotSame($p, $p2);
         $this->assertNull($r);
-        \GuzzleHttp\Promise\queue()->run();
-        $this->assertEquals('a', $r);
+        P\Utils::queue()->run();
+        $this->assertSame('a', $r);
     }
 
     public function testReturnsNewRejectedWhenOnFulfilledFails()
@@ -88,7 +90,7 @@ class FulfilledPromiseTest extends TestCase
             $p2->wait();
             $this->fail();
         } catch (\Exception $e) {
-            $this->assertEquals('b', $e->getMessage());
+            $this->assertSame('b', $e->getMessage());
         }
     }
 
@@ -105,6 +107,6 @@ class FulfilledPromiseTest extends TestCase
         $fp = new FulfilledPromise('a');
         $t1 = $fp->then(function ($v) { return $v . ' b'; });
         $t1->resolve('why!');
-        $this->assertEquals('why!', $t1->wait());
+        $this->assertSame('why!', $t1->wait());
     }
 }

--- a/tests/IsTest.php
+++ b/tests/IsTest.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace GuzzleHttp\Promise\Tests;
+
+use GuzzleHttp\Promise as P;
+use GuzzleHttp\Promise\FulfilledPromise;
+use GuzzleHttp\Promise\Promise;
+use GuzzleHttp\Promise\RejectedPromise;
+use PHPUnit\Framework\TestCase;
+
+class IsTest extends TestCase
+{
+    public function testKnowsIfFulfilled()
+    {
+        $p = new FulfilledPromise(null);
+        $this->assertTrue(P\Is::fulfilled($p));
+        $this->assertFalse(P\Is::rejected($p));
+    }
+
+    public function testKnowsIfRejected()
+    {
+        $p = new RejectedPromise(null);
+        $this->assertTrue(P\Is::rejected($p));
+        $this->assertFalse(P\Is::fulfilled($p));
+    }
+
+    public function testKnowsIfSettled()
+    {
+        $p = new RejectedPromise(null);
+        $this->assertTrue(P\Is::settled($p));
+        $this->assertFalse(P\Is::pending($p));
+    }
+
+    public function testKnowsIfPending()
+    {
+        $p = new Promise();
+        $this->assertFalse(P\Is::settled($p));
+        $this->assertTrue(P\Is::pending($p));
+    }
+}

--- a/tests/NotPromiseInstance.php
+++ b/tests/NotPromiseInstance.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace GuzzleHttp\Promise\Tests;
 
 use GuzzleHttp\Promise\Promise;

--- a/tests/RejectedPromiseTest.php
+++ b/tests/RejectedPromiseTest.php
@@ -1,6 +1,8 @@
 <?php
+
 namespace GuzzleHttp\Promise\Tests;
 
+use GuzzleHttp\Promise as P;
 use GuzzleHttp\Promise\Promise;
 use GuzzleHttp\Promise\RejectedPromise;
 use PHPUnit\Framework\TestCase;
@@ -13,12 +15,12 @@ class RejectedPromiseTest extends TestCase
     public function testThrowsReasonWhenWaitedUpon()
     {
         $p = new RejectedPromise('foo');
-        $this->assertEquals('rejected', $p->getState());
+        $this->assertTrue(P\Is::rejected($p));
         try {
             $p->wait(true);
             $this->fail();
         } catch (\Exception $e) {
-            $this->assertEquals('rejected', $p->getState());
+            $this->assertTrue(P\Is::rejected($p));
             $this->assertContains('foo', $e->getMessage());
         }
     }
@@ -27,7 +29,7 @@ class RejectedPromiseTest extends TestCase
     {
         $p = new RejectedPromise('foo');
         $p->cancel();
-        $this->assertEquals('rejected', $p->getState());
+        $this->assertTrue(P\Is::rejected($p));
     }
 
     /**
@@ -54,7 +56,7 @@ class RejectedPromiseTest extends TestCase
     {
         $p = new RejectedPromise('foo');
         $p->reject('foo');
-        $this->assertSame('rejected', $p->getState());
+        $this->assertTrue(P\Is::rejected($p));
     }
 
     public function testThrowsSpecificException()
@@ -90,8 +92,8 @@ class RejectedPromiseTest extends TestCase
         $f = function ($reason) use (&$r) { $r = $reason; };
         $p->then(null, $f);
         $this->assertNull($r);
-        \GuzzleHttp\Promise\queue()->run();
-        $this->assertEquals('a', $r);
+        P\Utils::queue()->run();
+        $this->assertSame('a', $r);
     }
 
     public function testReturnsNewRejectedWhenOnRejectedFails()
@@ -104,7 +106,7 @@ class RejectedPromiseTest extends TestCase
             $p2->wait();
             $this->fail();
         } catch (\Exception $e) {
-            $this->assertEquals('b', $e->getMessage());
+            $this->assertSame('b', $e->getMessage());
         }
     }
 
@@ -112,14 +114,14 @@ class RejectedPromiseTest extends TestCase
     {
         $p = new RejectedPromise('a');
         $p->wait(false);
-        $this->assertSame('rejected', $p->getState());
+        $this->assertTrue(P\Is::rejected($p));
     }
 
     public function testOtherwiseIsSugarForRejections()
     {
         $p = new RejectedPromise('foo');
         $p->otherwise(function ($v) use (&$c) { $c = $v; });
-        \GuzzleHttp\Promise\queue()->run();
+        P\Utils::queue()->run();
         $this->assertSame('foo', $c);
     }
 
@@ -132,8 +134,8 @@ class RejectedPromiseTest extends TestCase
         })->then(function ($v) use (&$actual) {
             $actual = $v;
         });
-        \GuzzleHttp\Promise\queue()->run();
-        $this->assertEquals('foo bar', $actual);
+        P\Utils::queue()->run();
+        $this->assertSame('foo bar', $actual);
     }
 
     public function testDoesNotTryToRejectTwiceDuringTrampoline()
@@ -141,6 +143,6 @@ class RejectedPromiseTest extends TestCase
         $fp = new RejectedPromise('a');
         $t1 = $fp->then(null, function ($v) { return $v . ' b'; });
         $t1->resolve('why!');
-        $this->assertEquals('why!', $t1->wait());
+        $this->assertSame('why!', $t1->wait());
     }
 }

--- a/tests/RejectionExceptionTest.php
+++ b/tests/RejectionExceptionTest.php
@@ -1,29 +1,9 @@
 <?php
+
 namespace GuzzleHttp\Promise\Tests;
 
 use GuzzleHttp\Promise\RejectionException;
 use PHPUnit\Framework\TestCase;
-
-class Thing1
-{
-    public function __construct($message)
-    {
-        $this->message = $message;
-    }
-
-    public function __toString()
-    {
-        return $this->message;
-    }
-}
-
-class Thing2 implements \JsonSerializable
-{
-    public function jsonSerialize()
-    {
-        return '{}';
-    }
-}
 
 /**
  * @covers GuzzleHttp\Promise\RejectionException
@@ -36,7 +16,7 @@ class RejectionExceptionTest extends TestCase
         $e = new RejectionException($thing);
 
         $this->assertSame($thing, $e->getReason());
-        $this->assertEquals('The promise was rejected with reason: foo', $e->getMessage());
+        $this->assertSame('The promise was rejected with reason: foo', $e->getMessage());
     }
 
     public function testCanGetReasonMessageFromJson()

--- a/tests/TaskQueueTest.php
+++ b/tests/TaskQueueTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace GuzzleHttp\Promise\Test;
 
 use GuzzleHttp\Promise\TaskQueue;
@@ -27,6 +28,6 @@ class TaskQueueTest extends TestCase
         $tq->add(function () use (&$called) { $called[] = 'b'; });
         $tq->add(function () use (&$called) { $called[] = 'c'; });
         $tq->run();
-        $this->assertEquals(['a', 'b', 'c'], $called);
+        $this->assertSame(['a', 'b', 'c'], $called);
     }
 }

--- a/tests/Thennable.php
+++ b/tests/Thennable.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace GuzzleHttp\Promise\Tests;
 
 use GuzzleHttp\Promise\Promise;

--- a/tests/Thing1.php
+++ b/tests/Thing1.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace GuzzleHttp\Promise\Tests;
+
+class Thing1
+{
+    public function __construct($message)
+    {
+        $this->message = $message;
+    }
+
+    public function __toString()
+    {
+        return $this->message;
+    }
+}

--- a/tests/Thing2.php
+++ b/tests/Thing2.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace GuzzleHttp\Promise\Tests;
+
+class Thing2 implements \JsonSerializable
+{
+    public function jsonSerialize()
+    {
+        return '{}';
+    }
+}


### PR DESCRIPTION
This PR pairs with https://github.com/guzzle/guzzle/pull/2712. After this is merged, we can tag 1.4.0.

### TODO:

- [x] Extract all functions to static class methods
- [x] Deprecate all functions and point to their replacements
- [x] Replace all uses in src
- [x] Update the tests
- [x] Update documentation and examples
- [x] Update change log

### Mappings:

| Original Function | Replacement Method |
|----------------|----------------|
| `queue` | `Utils::queue` |
| `task` | `Utils::task` |
| `promise_for` | `Create::promiseFor` |
| `rejection_for` | `Create::rejectionFor` |
| `exception_for` | `Create::exceptionFor` |
| `iter_for` | `Create::iterFor` |
| `inspect` | `Utils::inspect` |
| `inspect_all` | `Utils::inspectAll` |
| `unwrap` | `Utils::unwrap` |
| `all` | `Utils::all` |
| `some` | `Utils::some` |
| `any` | `Utils::any` |
| `settle` | `Utils::settle` |
| `each` | `Each::of` |
| `each_limit` | `Each::ofLimit` |
| `each_limit_all` | `Each::ofLimitAll` |
| `!is_fulfilled` | `Is::pending` |
| `is_fulfilled` | `Is::fulfilled` |
| `is_rejected` | `Is::rejected` |
| `is_settled` | `Is::settled` |
| `coroutine` | `Coroutine::of` |

NB The overall idea of these changes was approved by the original author, Michael: https://github.com/guzzle/promises/pull/108.