### PR TITLE
Fix memory leak

### DIFF
--- a/src/Promise.php
+++ b/src/Promise.php
@@ -196,7 +196,7 @@ class Promise implements PromiseInterface
                 /*
                  * If $f throws an exception, then $handler will be in the exception
                  * stack trace. Since $handler contains a reference to the callable
-                 * itself we get a circular reference. We clear clear the $handler
+                 * itself we get a circular reference. We clear the $handler
                  * here to avoid that memory leak.
                  */
                 $f = $handler[$index];

--- a/src/Promise.php
+++ b/src/Promise.php
@@ -193,7 +193,15 @@ class Promise implements PromiseInterface
 
         try {
             if (isset($handler[$index])) {
-                $promise->resolve($handler[$index]($value));
+                /*
+                 * If $f throws an exception, then $handler will be in the exception
+                 * stack trace. Since $handler contains a reference to the callable
+                 * itself we get a circular reference. We clear clear the $handler
+                 * here to avoid that memory leak.
+                 */
+                $f = $handler[$index];
+                unset($handler);
+                $promise->resolve($f($value));
             } elseif ($index === 1) {
                 // Forward resolution values as-is.
                 $promise->resolve($value);


### PR DESCRIPTION
Make sure we dont have a reference to the closure in the exception stack trace. 

fix https://github.com/guzzle/guzzle/issues/2606
fix https://github.com/hyperf/hyperf/issues/1486
fix #109 