### PR TITLE
Run queue when waiting on fulfilled promise

### DIFF
--- a/src/FulfilledPromise.php
+++ b/src/FulfilledPromise.php
@@ -57,6 +57,8 @@ class FulfilledPromise implements PromiseInterface
 
     public function wait($unwrap = true, $defaultDelivery = null)
     {
+        Utils::queue()->run();
+
         return $unwrap ? $this->value : null;
     }
 

--- a/tests/FulfilledPromiseTest.php
+++ b/tests/FulfilledPromiseTest.php
@@ -81,6 +81,17 @@ class FulfilledPromiseTest extends TestCase
         $this->assertSame('a', $r);
     }
 
+    public function testRunsQueueOnWait()
+    {
+        $p = new FulfilledPromise('a');
+        $r = null;
+        $f = function ($d) use (&$r) { $r = $d; };
+        $p->then($f);
+        $this->assertNull($r);
+        $p->wait();
+        $this->assertSame('a', $r);
+    }
+
     public function testReturnsNewRejectedWhenOnFulfilledFails()
     {
         $p = new FulfilledPromise('a');


### PR DESCRIPTION
**Description**
<!-- A clear and concise description of the problem. -->
This PR tries to fix an inconsistency when waiting for a `FulfilledPromise`.

As a developer I expect that the `$onFulfilled` callback will be resolved as soon as I call `wait()` on any implementation of `PromiseInterface`.

Right now, the `then()` function on a fulfilled promise returns a new promise, which has to be resolved. This seems pretty confusing to me, since this is different to how a normal promise is handled.

**How to reproduce**

See reproducer in https://github.com/jaylinski/guzzle-fulfilled-wait/blob/master/test.php.

**Possible Solution**
Merge this PR.

**Additional context**
This may break other assumptions. See https://github.com/guzzle/promises/issues/14.
