### PR TITLE
Use incrementing counter to generate pending indexes.

### DIFF
--- a/src/EachPromise.php
+++ b/src/EachPromise.php
@@ -123,6 +123,7 @@ class EachPromise implements PromisorInterface
         $clearFn = function () {
             $this->iterable = $this->concurrency = $this->pending = null;
             $this->onFulfilled = $this->onRejected = null;
+            $this->nextPendingIndex = 0;
         };
 
         $this->aggregate->then($clearFn, $clearFn);

--- a/src/EachPromise.php
+++ b/src/EachPromise.php
@@ -10,6 +10,8 @@ class EachPromise implements PromisorInterface
 {
     private $pending = [];
 
+    private $nextPendingIndex = 0;
+
     /** @var \Iterator|null */
     private $iterable;
 
@@ -163,11 +165,9 @@ class EachPromise implements PromisorInterface
         $promise = Create::promiseFor($this->iterable->current());
         $key = $this->iterable->key();
 
-        // Iterable keys may not be unique, so we add the promises at the end
-        // of the pending array and retrieve the array index being used
-        $this->pending[] = null;
-        end($this->pending);
-        $idx = key($this->pending);
+        // Iterable keys may not be unique, so we use a counter to
+        // guarantee uniqueness
+        $idx = $this->nextPendingIndex++;
 
         $this->pending[$idx] = $promise->then(
             function ($value) use ($idx, $key) {

--- a/tests/EachPromiseTest.php
+++ b/tests/EachPromiseTest.php
@@ -385,4 +385,25 @@ class EachPromiseTest extends TestCase
         $each->promise()->wait();
         $this->assertSame(4, $called);
     }
+
+    public function testIsWaitableWhenLimited()
+    {
+        $promises = [
+            $this->createSelfResolvingPromise('a'),
+            $this->createSelfResolvingPromise('c'),
+            $this->createSelfResolvingPromise('b'),
+            $this->createSelfResolvingPromise('d')
+        ];
+        $called = [];
+        $each = new EachPromise($promises, [
+            'concurrency' => 2,
+            'fulfilled' => function ($value) use (&$called) {
+                $called[] = $value;
+            }
+        ]);
+        $p = $each->promise();
+        $this->assertNull($p->wait());
+        $this->assertSame(['a', 'c', 'b', 'd'], $called);
+        $this->assertTrue(P\Is::fulfilled($p));
+    }
 }


### PR DESCRIPTION
Using end() moves the internal array pointer and breaks the
iteration taking place in the promises wait function.

Use an incrementing counter to generate unique indexes for
the pending array instead.

Fixes #133 