### PR TITLE
Call handler when waiting on fulfilled/rejected Promise

### DIFF
--- a/src/RejectedPromise.php
+++ b/src/RejectedPromise.php
@@ -12,6 +12,12 @@ class RejectedPromise implements PromiseInterface
 {
     private $reason;
 
+    /** @var Promise|null */
+    private $promise;
+
+    /** @var callable|null */
+    private $onRejected;
+
     public function __construct($reason)
     {
         if (is_object($reason) && method_exists($reason, 'then')) {
@@ -32,21 +38,14 @@ class RejectedPromise implements PromiseInterface
             return $this;
         }
 
+        $this->onRejected = $onRejected;
+
         $queue = Utils::queue();
         $reason = $this->reason;
-        $p = new Promise([$queue, 'run']);
+        $p = $this->promise = new Promise([$queue, 'run']);
         $queue->add(static function () use ($p, $reason, $onRejected) {
             if (Is::pending($p)) {
-                try {
-                    // Return a resolved promise if onRejected does not throw.
-                    $p->resolve($onRejected($reason));
-                } catch (\Throwable $e) {
-                    // onRejected threw, so return a rejected promise.
-                    $p->reject($e);
-                } catch (\Exception $e) {
-                    // onRejected threw, so return a rejected promise.
-                    $p->reject($e);
-                }
+                self::callHandler($p, $reason, $onRejected);
             }
         });
 
@@ -62,6 +61,11 @@ class RejectedPromise implements PromiseInterface
     {
         if ($unwrap) {
             throw Create::exceptionFor($this->reason);
+        }
+
+        // Don't run the queue to avoid deadlocks, instead directly reject the promise.
+        if ($this->promise && Is::pending($this->promise)) {
+            self::callHandler($this->promise, $this->reason, $this->onRejected);
         }
 
         return null;
@@ -87,5 +91,16 @@ class RejectedPromise implements PromiseInterface
     public function cancel()
     {
         // pass
+    }
+
+    private static function callHandler(Promise $promise, $reason, callable $handler)
+    {
+        try {
+            $promise->resolve($handler($reason));
+        } catch (\Throwable $e) {
+            $promise->reject($e);
+        } catch (\Exception $e) {
+            $promise->reject($e);
+        }
     }
 }

--- a/tests/FulfilledPromiseTest.php
+++ b/tests/FulfilledPromiseTest.php
@@ -81,6 +81,17 @@ class FulfilledPromiseTest extends TestCase
         $this->assertSame('a', $r);
     }
 
+    public function testInvokesOnFulfilledOnWait()
+    {
+        $p = new FulfilledPromise('a');
+        $r = null;
+        $f = function ($d) use (&$r) { $r = $d; };
+        $p->then($f);
+        $this->assertNull($r);
+        $p->wait();
+        $this->assertSame('a', $r);
+    }
+
     public function testReturnsNewRejectedWhenOnFulfilledFails()
     {
         $p = new FulfilledPromise('a');
@@ -109,5 +120,6 @@ class FulfilledPromiseTest extends TestCase
         $t1 = $fp->then(function ($v) { return $v . ' b'; });
         $t1->resolve('why!');
         $this->assertSame('why!', $t1->wait());
+        P\Utils::queue()->run();
     }
 }

--- a/tests/RejectedPromiseTest.php
+++ b/tests/RejectedPromiseTest.php
@@ -97,6 +97,17 @@ class RejectedPromiseTest extends TestCase
         $this->assertSame('a', $r);
     }
 
+    public function testInvokesOnRejectedOnWait()
+    {
+        $p = new RejectedPromise('a');
+        $r = null;
+        $f = function ($reason) use (&$r) { $r = $reason; };
+        $p->then(null, $f);
+        $this->assertNull($r);
+        $p->wait(false);
+        $this->assertSame('a', $r);
+    }
+
     public function testReturnsNewRejectedWhenOnRejectedFails()
     {
         $p = new RejectedPromise('a');
@@ -145,5 +156,6 @@ class RejectedPromiseTest extends TestCase
         $t1 = $fp->then(null, function ($v) { return $v . ' b'; });
         $t1->resolve('why!');
         $this->assertSame('why!', $t1->wait());
+        P\Utils::queue()->run();
     }
 }


### PR DESCRIPTION
**Description**
<!-- A clear and concise description of the problem. -->
This PR tries to fix an inconsistency when waiting for a `FulfilledPromise` and `RejectedPromise`.

As a developer I expect that the `$onFulfilled` callback will be resolved as soon as I call `wait()` on any implementation of `PromiseInterface`.

Right now, the `then()` function on a fulfilled promise returns a new promise, which has to be resolved. This seems pretty confusing to me, since this is different to how a normal promise is handled.

**How to reproduce**

See reproducer in https://github.com/jaylinski/guzzle-fulfilled-wait/blob/master/test.php.

**Possible Solution**

Merge this PR.

**Additional context**

This is a follow-up from #131.
