### PR TITLE
Grammatical errors fixed.

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,8 +60,8 @@ $promise->then(
 ```
 
 *Resolving* a promise means that you either fulfill a promise with a *value* or
-reject a promise with a *reason*. Resolving a promises triggers callbacks
-registered with the promises's `then` method. These callbacks are triggered
+reject a promise with a *reason*. Resolving a promise triggers callbacks
+registered with the promises' `then` method. These callbacks are triggered
 only once and in the order in which they were added.
 
 


### PR DESCRIPTION
In the Callbacks section, there are grammatical errors, in the last paragraph, which is just below the code snippet.
The sentence is written as, "Resolving a promise means that you either fulfill a promise with a value or reject a promise with a reason. Resolving a promises triggers callbacks registered with the promises's then method."

The corrected sentence could be written as, "Resolving a promise means that you either fulfill a promise with a value or reject a promise with a reason. Resolving a **promise** triggers callbacks registered with the **promises'** then method. 

Thank you.