### PR TITLE
Fix inspect aggregate rejection reason

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # CHANGELOG
 
 
+## 2.3.1 - 2026-05-19
+
+### Fixed
+
+- Fixed `Utils::inspect()` returning the internal reason array instead of the `AggregateException` when inspecting failed `Utils::some()` or `Utils::any()` promises.
+
+
 ## 2.3.0 - 2025-08-22
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # CHANGELOG
 
 
-## 2.3.1 - 2026-05-19
+## 2.3.1 - Upcoming
 
 ### Fixed
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,0 +1,2 @@
+parameters:
+	ignoreErrors: []

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,8 +1,0 @@
-parameters:
-	ignoreErrors:
-		-
-			message: '#^Dead catch \- GuzzleHttp\\Promise\\RejectionException is never thrown in the try block\.$#'
-			identifier: catch.neverThrown
-			count: 1
-			path: src/Utils.php
-

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,6 +1,3 @@
-includes:
-    - phpstan-baseline.neon
-
 parameters:
     level: 5
     paths:

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,3 +1,6 @@
+includes:
+    - phpstan-baseline.neon
+
 parameters:
     level: 5
     paths:

--- a/src/Utils.php
+++ b/src/Utils.php
@@ -76,9 +76,15 @@ final class Utils
                 'state' => PromiseInterface::FULFILLED,
                 'value' => $promise->wait(),
             ];
-        } catch (RejectionException $e) {
-            return ['state' => PromiseInterface::REJECTED, 'reason' => $e->getReason()];
         } catch (\Throwable $e) {
+            if ($e instanceof AggregateException) {
+                return ['state' => PromiseInterface::REJECTED, 'reason' => $e];
+            }
+
+            if ($e instanceof RejectionException) {
+                return ['state' => PromiseInterface::REJECTED, 'reason' => $e->getReason()];
+            }
+
             return ['state' => PromiseInterface::REJECTED, 'reason' => $e];
         }
     }

--- a/tests/UtilsTest.php
+++ b/tests/UtilsTest.php
@@ -140,6 +140,18 @@ class UtilsTest extends TestCase
         $this->assertContains('bad', $called->getReason());
     }
 
+    public function testInspectPreservesAggregateExceptionFromSome(): void
+    {
+        $a = new Promise(function () use (&$a): void { $a->reject('bad'); });
+        $b = new Promise(function () use (&$b): void { $b->resolve('good'); });
+
+        $result = P\Utils::inspect(P\Utils::some(2, [$a, $b]));
+
+        $this->assertSame(PromiseInterface::REJECTED, $result['state']);
+        $this->assertInstanceOf(AggregateException::class, $result['reason']);
+        $this->assertContains('bad', $result['reason']->getReason());
+    }
+
     public function testCanWaitUntilSomeCountIsSatisfied(): void
     {
         $a = new Promise(function () use (&$a): void { $a->resolve('a'); });


### PR DESCRIPTION
Fixes `Utils::inspect()` so failed `Utils::some()` and `Utils::any()` promises report the `AggregateException` itself instead of its internal reason array.

This keeps the current 2.x scalar rejection behavior, adds a regression test, updates the changelog, and leaves the PHPStan baseline file in place with no ignored errors.