### PR TITLE
Return actual inspect rejection reasons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,7 @@
 ### Changed
 
 - Changed `Utils::inspect()` and `Utils::inspectAll()` to return the actual promise rejection reason instead of unwrapping `RejectionException` reasons
-
-### Fixed
-
-- Fixed rejection callbacks not being invoked when `then()` is called after a promise was resolved with a rejected promise
+- Changed rejection callbacks to be invoked when `then()` is called after a promise was resolved with a rejected promise
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@
 
 ## 3.0.0 - Unreleased
 
+### Changed
+
+- Changed `Utils::inspect()` and `Utils::inspectAll()` to return the actual promise rejection reason instead of unwrapping `RejectionException` reasons
+
+### Fixed
+
+- Fixed rejection callbacks not being invoked when `then()` is called after a promise was resolved with a rejected promise
+
 ### Removed
 
 - Dropped support for PHP 7.2 and 7.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,8 @@
 
 ### Changed
 
-- Changed `Utils::inspect()` and `Utils::inspectAll()` to return the actual promise rejection reason instead of unwrapping `RejectionException` reasons
-- Changed rejection callbacks to be invoked when `then()` is called after a promise was resolved with a rejected promise
+- Changed `Utils::inspect()` to return actual rejection reasons
+- Changed late rejection callbacks to follow rejected promises
 
 ### Removed
 

--- a/README.md
+++ b/README.md
@@ -288,6 +288,16 @@ wait function will be the value delivered to promise B.
 **Note**: when you do not unwrap the promise, no value is returned.
 
 
+### Inspecting a Promise
+
+`Utils::inspect($promise)` waits for a promise to settle and returns an array
+describing its final state. For rejected promises, the `reason` entry is the
+actual rejection reason delivered to rejection callbacks.
+
+This means `RejectionException` and subclasses are not unwrapped by `inspect()`.
+For example, cancelled promises inspect with a `CancellationException` reason.
+
+
 ## Cancellation
 
 You can cancel a promise that has not yet been fulfilled using the `cancel()`

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,18 +1,25 @@
-# Guzzle Promises Upgrade Guide
+Guzzle Promises Upgrade Guide
+=============================
 
+2.x to 3.0
+----------
 
-## 2.x to 3.0
+#### PHP Version and Dependencies
 
-### PHP Version
+Guzzle Promises 3.0 requires PHP `^7.4 || ^8.0`. Guzzle Promises 2.x supported
+PHP `^7.2.5 || ^8.0`.
 
-Guzzle Promises 3.0 requires PHP 7.4 or later. PHP 7.2 and 7.3 are no longer supported.
+If your application still supports PHP 7.2 or 7.3, continue using Guzzle
+Promises 2.x until your minimum PHP version is raised.
 
+#### Promise Inspection
 
-### Promise Inspection
+`Utils::inspect()` and `Utils::inspectAll()` now return the actual rejection
+reason delivered to rejection callbacks. They no longer unwrap
+`RejectionException` instances to their inner reason.
 
-`Utils::inspect()` and `Utils::inspectAll()` now return the actual rejection reason delivered to rejection callbacks. They no longer unwrap `RejectionException` instances to their inner reason.
-
-For example, a promise rejected with a `RejectionException` now inspects with that exception as the reason:
+For example, a promise rejected with a `RejectionException` now inspects with
+that exception as the reason:
 
 ```php
 use GuzzleHttp\Promise\RejectedPromise;
@@ -25,12 +32,14 @@ $result = Utils::inspect(new RejectedPromise($reason));
 assert($result['reason'] === $reason);
 ```
 
-Cancelled promises now inspect with a `CancellationException` reason. If you need the string reason from a `RejectionException` or subclass, call `getReason()` on the exception.
+Cancelled promises now inspect with a `CancellationException` reason. If you need
+the string reason from a `RejectionException` or subclass, call `getReason()` on
+the exception.
 
+#### Late Rejection Callbacks
 
-### Late Rejection Callbacks
-
-Rejection callbacks registered after a promise was resolved with a rejected promise are now invoked with the nested rejection reason.
+Rejection callbacks registered after a promise was resolved with a rejected
+promise are now invoked with the nested rejection reason.
 
 ```php
 use GuzzleHttp\Promise\Promise;

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,0 +1,48 @@
+# Guzzle Promises Upgrade Guide
+
+
+## 2.x to 3.0
+
+### PHP Version
+
+Guzzle Promises 3.0 requires PHP 7.4 or later. PHP 7.2 and 7.3 are no longer supported.
+
+
+### Promise Inspection
+
+`Utils::inspect()` and `Utils::inspectAll()` now return the actual rejection reason delivered to rejection callbacks. They no longer unwrap `RejectionException` instances to their inner reason.
+
+For example, a promise rejected with a `RejectionException` now inspects with that exception as the reason:
+
+```php
+use GuzzleHttp\Promise\RejectedPromise;
+use GuzzleHttp\Promise\RejectionException;
+use GuzzleHttp\Promise\Utils;
+
+$reason = new RejectionException('reason');
+$result = Utils::inspect(new RejectedPromise($reason));
+
+assert($result['reason'] === $reason);
+```
+
+Cancelled promises now inspect with a `CancellationException` reason. If you need the string reason from a `RejectionException` or subclass, call `getReason()` on the exception.
+
+
+### Late Rejection Callbacks
+
+Rejection callbacks registered after a promise was resolved with a rejected promise are now invoked with the nested rejection reason.
+
+```php
+use GuzzleHttp\Promise\Promise;
+use GuzzleHttp\Promise\RejectedPromise;
+use GuzzleHttp\Promise\Utils;
+
+$promise = new Promise();
+$promise->resolve(new RejectedPromise('reason'));
+
+$promise->then(null, function ($reason): void {
+    assert($reason === 'reason');
+});
+
+Utils::queue()->run();
+```

--- a/src/Promise.php
+++ b/src/Promise.php
@@ -49,7 +49,7 @@ class Promise implements PromiseInterface
         if ($this->state === self::FULFILLED) {
             $promise = Create::promiseFor($this->result);
 
-            return $onFulfilled ? $promise->then($onFulfilled) : $promise;
+            return $promise->then($onFulfilled, $onRejected);
         }
 
         // It's either cancelled or rejected, so return a rejected promise

--- a/src/Utils.php
+++ b/src/Utils.php
@@ -71,22 +71,45 @@ final class Utils
      */
     public static function inspect(PromiseInterface $promise): array
     {
+        $result = null;
+        $getResult = static function () use (&$result): ?array {
+            return $result;
+        };
+
+        $inspection = $promise->then(
+            static function ($value) use (&$result): void {
+                $result = ['state' => PromiseInterface::FULFILLED, 'value' => $value];
+            },
+            static function ($reason) use (&$result): void {
+                $result = ['state' => PromiseInterface::REJECTED, 'reason' => $reason];
+            }
+        );
+
         try {
-            return [
-                'state' => PromiseInterface::FULFILLED,
-                'value' => $promise->wait(),
-            ];
+            $inspection->wait(false);
         } catch (\Throwable $e) {
-            if ($e instanceof AggregateException) {
-                return ['state' => PromiseInterface::REJECTED, 'reason' => $e];
+            $settled = $getResult();
+            if (null !== $settled) {
+                return $settled;
             }
 
-            if ($e instanceof RejectionException) {
-                return ['state' => PromiseInterface::REJECTED, 'reason' => $e->getReason()];
+            if (Is::settled($promise)) {
+                try {
+                    self::queue()->run();
+                } catch (\Throwable $queueError) {
+                    return ['state' => PromiseInterface::REJECTED, 'reason' => $queueError];
+                }
+
+                $settled = $getResult();
+                if (null !== $settled) {
+                    return $settled;
+                }
             }
 
             return ['state' => PromiseInterface::REJECTED, 'reason' => $e];
         }
+
+        return $getResult() ?? ['state' => $promise->getState()];
     }
 
     /**

--- a/tests/PromiseTest.php
+++ b/tests/PromiseTest.php
@@ -382,6 +382,20 @@ class PromiseTest extends TestCase
         $this->assertSame('foo', $carry);
     }
 
+    public function testForwardsRejectedPromiseWhenResolvedBeforeThen(): void
+    {
+        $p = new Promise();
+        $p->resolve(new RejectedPromise('inner'));
+
+        $result = null;
+        $p->then(null, function ($reason) use (&$result): void {
+            $result = $reason;
+        });
+
+        P\Utils::queue()->run();
+        $this->assertSame('inner', $result);
+    }
+
     public function testCreatesPromiseWhenRejectedWithNoCallback(): void
     {
         $p = new Promise();

--- a/tests/UtilsTest.php
+++ b/tests/UtilsTest.php
@@ -244,6 +244,38 @@ class UtilsTest extends TestCase
         ], P\Utils::inspect($p));
     }
 
+    public function testInspectPreservesRejectionExceptionAsReason(): void
+    {
+        $reason = new RejectionException('inner');
+        $result = P\Utils::inspect(new RejectedPromise($reason));
+
+        $this->assertSame(PromiseInterface::REJECTED, $result['state']);
+        $this->assertSame($reason, $result['reason']);
+    }
+
+    public function testInspectPreservesCancellationExceptionAsReason(): void
+    {
+        $promise = new Promise();
+        $promise->cancel();
+
+        $result = P\Utils::inspect($promise);
+
+        $this->assertSame(PromiseInterface::REJECTED, $result['state']);
+        $this->assertInstanceOf(P\CancellationException::class, $result['reason']);
+        $this->assertSame('Promise has been cancelled', $result['reason']->getReason());
+    }
+
+    public function testInspectHandlesPromiseResolvedWithRejectedPromise(): void
+    {
+        $promise = new Promise();
+        $promise->resolve(new RejectedPromise('inner'));
+
+        $result = P\Utils::inspect($promise);
+
+        $this->assertSame(PromiseInterface::REJECTED, $result['state']);
+        $this->assertSame('inner', $result['reason']);
+    }
+
     public function testReturnsTrampoline(): void
     {
         $this->assertInstanceOf(TaskQueue::class, P\Utils::queue());
@@ -700,7 +732,8 @@ class UtilsTest extends TestCase
         });
 
         $res = P\Utils::inspect($co);
-        $this->assertSame('f', $res['reason']);
+        $this->assertInstanceOf(RejectionException::class, $res['reason']);
+        $this->assertSame('f', $res['reason']->getReason());
     }
 
     public function testCoroutineOtherwiseIntegrationTest(): void
@@ -737,10 +770,10 @@ class UtilsTest extends TestCase
 
         $results = P\Utils::inspectAll([$p1, $p2, $p3]);
 
-        $this->assertSame([
-            ['state' => 'rejected', 'reason' => 'Promise has been cancelled'],
-            ['state' => 'fulfilled', 'value' => 'b2'],
-            ['state' => 'fulfilled', 'value' => 'c'],
-        ], $results);
+        $this->assertSame(PromiseInterface::REJECTED, $results[0]['state']);
+        $this->assertInstanceOf(P\CancellationException::class, $results[0]['reason']);
+        $this->assertSame('Promise has been cancelled', $results[0]['reason']->getReason());
+        $this->assertSame(['state' => 'fulfilled', 'value' => 'b2'], $results[1]);
+        $this->assertSame(['state' => 'fulfilled', 'value' => 'c'], $results[2]);
     }
 }


### PR DESCRIPTION
Updates `Utils::inspect()` for 3.0 so rejected promises report the actual rejection reason delivered to rejection callbacks, rather than unwrapping `RejectionException` reasons. Also fixes late rejection handlers for promises that were already resolved with a rejected promise, and documents the changed inspection semantics.
