### PR TITLE
[2.4] Fix empty EachPromise queue completion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 
 ## 2.4.0 - Upcoming
 
-### Fixed
+### Changed
 
 - Fixed empty `EachPromise` instances remaining pending when the task queue is run without calling `wait()`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 
 ### Changed
 
-- Fixed empty `EachPromise` instances remaining pending when the task queue is run without calling `wait()`.
+- Empty `EachPromise` instances now resolve when the task queue runs without `wait()`
 
 
 ## 2.3.1 - 2026-05-19

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # CHANGELOG
 
 
+## 2.4.0 - Upcoming
+
+### Fixed
+
+- Fixed empty `EachPromise` instances remaining pending when the task queue is run without calling `wait()`.
+
+
 ## 2.3.1 - 2026-05-19
 
 ### Fixed

--- a/src/EachPromise.php
+++ b/src/EachPromise.php
@@ -84,6 +84,19 @@ class EachPromise implements PromisorInterface
             /** @psalm-assert Promise $this->aggregate */
             $this->iterable->rewind();
             $this->refillPending();
+            if (!$this->pending) {
+                Utils::queue()->add(function (): void {
+                    if (!$this->aggregate || Is::settled($this->aggregate)) {
+                        return;
+                    }
+
+                    try {
+                        $this->checkIfFinished();
+                    } catch (\Throwable $e) {
+                        $this->aggregate->reject($e);
+                    }
+                });
+            }
         } catch (\Throwable $e) {
             $this->aggregate->reject($e);
         }

--- a/tests/EachPromiseTest.php
+++ b/tests/EachPromiseTest.php
@@ -52,6 +52,46 @@ class EachPromiseTest extends TestCase
         $this->assertFalse($onRejectedCalled);
     }
 
+    public function testResolvesEmptyGeneratorWhenQueueRuns(): void
+    {
+        $iter = static function (): \Generator {
+            if (false) {
+                yield 1;
+            }
+        };
+        $each = new EachPromise($iter());
+        $p = $each->promise();
+        $called = false;
+        $value = 'not called';
+        $p->then(function ($result) use (&$called, &$value): void {
+            $called = true;
+            $value = $result;
+        });
+
+        $this->assertTrue(P\Is::pending($p));
+        $this->assertFalse($called);
+
+        P\Utils::queue()->run();
+
+        $this->assertTrue(P\Is::fulfilled($p));
+        $this->assertTrue($called);
+        $this->assertNull($value);
+    }
+
+    public function testDoesNotResolveNonEmptyListWithNoDynamicConcurrencyWhenQueueRuns(): void
+    {
+        $each = new EachPromise([new FulfilledPromise('a')], [
+            'concurrency' => static function (): int {
+                return 0;
+            },
+        ]);
+        $p = $each->promise();
+
+        P\Utils::queue()->run();
+
+        $this->assertTrue(P\Is::pending($p));
+    }
+
     public function testInvokesAllPromises(): void
     {
         $promises = [new Promise(), new Promise(), new Promise()];
@@ -187,6 +227,21 @@ class EachPromiseTest extends TestCase
         $this->assertNull(PropertyHelper::get($each, 'pending'));
         $this->assertNull(PropertyHelper::get($each, 'concurrency'));
         $this->assertTrue($called);
+    }
+
+    public function testClearsReferencesWhenEmptyListResolvedByQueue(): void
+    {
+        $each = new EachPromise([]);
+        $p = $each->promise();
+
+        P\Utils::queue()->run();
+
+        $this->assertTrue(P\Is::fulfilled($p));
+        $this->assertNull(PropertyHelper::get($each, 'onFulfilled'));
+        $this->assertNull(PropertyHelper::get($each, 'onRejected'));
+        $this->assertNull(PropertyHelper::get($each, 'iterable'));
+        $this->assertNull(PropertyHelper::get($each, 'pending'));
+        $this->assertNull(PropertyHelper::get($each, 'concurrency'));
     }
 
     public function testCanBeCancelled(): void


### PR DESCRIPTION
Fixes #176.

This keeps the existing aggregate promise and lets an empty EachPromise complete when the task queue runs.