### PR TITLE
[2.5] Deprecate non-iterable collections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # CHANGELOG
 
 
+## 2.5.0 - Upcoming
+
+### Deprecated
+
+- Deprecated passing non-iterable inputs to promise collection helpers and `EachPromise`
+
+
 ## 2.4.0 - 2026-05-20
 
 ### Changed

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,8 @@
         }
     ],
     "require": {
-        "php": "^7.2.5 || ^8.0"
+        "php": "^7.2.5 || ^8.0",
+        "symfony/deprecation-contracts": "^2.5 || ^3.0"
     },
     "require-dev": {
         "bamarni/composer-bin-plugin": "^1.8.2",

--- a/src/Create.php
+++ b/src/Create.php
@@ -74,6 +74,16 @@ final class Create
             return new \ArrayIterator($value);
         }
 
+        if (!is_iterable($value)) {
+            \trigger_deprecation(
+                'guzzlehttp/promises',
+                '2.5',
+                'Passing a non-iterable to %s::%s() is deprecated; guzzlehttp/promises 3.0 will require an iterable.',
+                __CLASS__,
+                __FUNCTION__
+            );
+        }
+
         return new \ArrayIterator([$value]);
     }
 }

--- a/src/Each.php
+++ b/src/Each.php
@@ -26,6 +26,8 @@ final class Each
         ?callable $onFulfilled = null,
         ?callable $onRejected = null
     ): PromiseInterface {
+        $iterable = self::prepareIterable($iterable, __FUNCTION__);
+
         return (new EachPromise($iterable, [
             'fulfilled' => $onFulfilled,
             'rejected' => $onRejected,
@@ -49,6 +51,8 @@ final class Each
         ?callable $onFulfilled = null,
         ?callable $onRejected = null
     ): PromiseInterface {
+        $iterable = self::prepareIterable($iterable, __FUNCTION__);
+
         return (new EachPromise($iterable, [
             'fulfilled' => $onFulfilled,
             'rejected' => $onRejected,
@@ -69,6 +73,8 @@ final class Each
         $concurrency,
         ?callable $onFulfilled = null
     ): PromiseInterface {
+        $iterable = self::prepareIterable($iterable, __FUNCTION__);
+
         return self::ofLimit(
             $iterable,
             $concurrency,
@@ -77,5 +83,22 @@ final class Each
                 $aggregate->reject($reason);
             }
         );
+    }
+
+    private static function prepareIterable($iterable, string $method): iterable
+    {
+        if (is_iterable($iterable)) {
+            return $iterable;
+        }
+
+        \trigger_deprecation(
+            'guzzlehttp/promises',
+            '2.5',
+            'Passing a non-iterable to %s::%s() is deprecated; guzzlehttp/promises 3.0 will require an iterable.',
+            self::class,
+            $method
+        );
+
+        return [$iterable];
     }
 }

--- a/src/EachPromise.php
+++ b/src/EachPromise.php
@@ -57,6 +57,18 @@ class EachPromise implements PromisorInterface
      */
     public function __construct($iterable, array $config = [])
     {
+        if (!is_iterable($iterable)) {
+            \trigger_deprecation(
+                'guzzlehttp/promises',
+                '2.5',
+                'Passing a non-iterable to %s::%s() is deprecated; guzzlehttp/promises 3.0 will require an iterable.',
+                __CLASS__,
+                __FUNCTION__
+            );
+
+            $iterable = [$iterable];
+        }
+
         $this->iterable = Create::iterFor($iterable);
 
         if (isset($config['concurrency'])) {

--- a/src/Utils.php
+++ b/src/Utils.php
@@ -101,6 +101,8 @@ final class Utils
      */
     public static function inspectAll($promises): array
     {
+        self::triggerNonIterableDeprecation($promises, __FUNCTION__);
+
         $results = [];
         foreach ($promises as $key => $promise) {
             $results[$key] = self::inspect($promise);
@@ -122,6 +124,8 @@ final class Utils
      */
     public static function unwrap($promises): array
     {
+        self::triggerNonIterableDeprecation($promises, __FUNCTION__);
+
         $results = [];
         foreach ($promises as $key => $promise) {
             $results[$key] = $promise->wait();
@@ -143,6 +147,8 @@ final class Utils
      */
     public static function all($promises, bool $recursive = false): PromiseInterface
     {
+        $promises = self::prepareIterable($promises, __FUNCTION__);
+
         $results = [];
         $promise = Each::of(
             $promises,
@@ -191,6 +197,8 @@ final class Utils
      */
     public static function some(int $count, $promises): PromiseInterface
     {
+        $promises = self::prepareIterable($promises, __FUNCTION__);
+
         $results = [];
         $rejections = [];
 
@@ -231,6 +239,8 @@ final class Utils
      */
     public static function any($promises): PromiseInterface
     {
+        $promises = self::prepareIterable($promises, __FUNCTION__);
+
         return self::some(1, $promises)->then(function ($values) {
             return $values[0];
         });
@@ -248,6 +258,8 @@ final class Utils
      */
     public static function settle($promises): PromiseInterface
     {
+        $promises = self::prepareIterable($promises, __FUNCTION__);
+
         $results = [];
 
         return Each::of(
@@ -263,5 +275,31 @@ final class Utils
 
             return $results;
         });
+    }
+
+    private static function prepareIterable($promises, string $method): iterable
+    {
+        if (is_iterable($promises)) {
+            return $promises;
+        }
+
+        self::triggerNonIterableDeprecation($promises, $method);
+
+        return [$promises];
+    }
+
+    private static function triggerNonIterableDeprecation($promises, string $method): void
+    {
+        if (is_iterable($promises)) {
+            return;
+        }
+
+        \trigger_deprecation(
+            'guzzlehttp/promises',
+            '2.5',
+            'Passing a non-iterable to %s::%s() is deprecated; guzzlehttp/promises 3.0 will require an iterable.',
+            self::class,
+            $method
+        );
     }
 }

--- a/tests/EachTest.php
+++ b/tests/EachTest.php
@@ -15,7 +15,7 @@ class EachTest extends TestCase
     public function testCallsEachLimit(): void
     {
         $p = new Promise();
-        $aggregate = P\Each::ofLimit($p, 2);
+        $aggregate = P\Each::ofLimit([$p], 2);
 
         $p->resolve('a');
         P\Utils::queue()->run();


### PR DESCRIPTION
This deprecates passing non-iterable inputs to promise collection helpers.