### PR TITLE
[3.0] Allow resolving promises without a value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 ### Added
 
 - Added generic PHPDoc annotations to promise APIs
+- Allowed promises to be resolved without passing a value
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -81,10 +81,11 @@ only once and in the order in which they were added.
 
 ### Resolving a Promise
 
-Promises are fulfilled using the `resolve($value)` method. Resolving a promise
-with any value other than a `GuzzleHttp\Promise\RejectedPromise` will trigger
-all of the onFulfilled callbacks (resolving a promise with a rejected promise
-will reject the promise and trigger the `$onRejected` callbacks).
+Promises are fulfilled using the `resolve($value = null)` method. Calling
+`resolve()` without an argument fulfills the promise with `null`. Resolving a
+promise with any value other than a `GuzzleHttp\Promise\RejectedPromise` will
+trigger all of the onFulfilled callbacks (resolving a promise with a rejected
+promise will reject the promise and trigger the `$onRejected` callbacks).
 
 ```php
 use GuzzleHttp\Promise\Promise;
@@ -362,9 +363,10 @@ A promise has the following methods:
   Returns the state of the promise. One of `pending`, `fulfilled`, or
   `rejected`.
 
-- `resolve($value)`
+- `resolve($value = null)`
 
-  Fulfills the promise with the given `$value`.
+  Fulfills the promise with the given `$value`, or with `null` if no value is
+  given.
 
 - `reject($reason)`
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -12,6 +12,14 @@ PHP `^7.2.5 || ^8.0`.
 If your application still supports PHP 7.2 or 7.3, continue using Guzzle
 Promises 2.x until your minimum PHP version is raised.
 
+#### Optional Promise Resolution Values
+
+`PromiseInterface::resolve()` now accepts an optional value. Calling `resolve()`
+without an argument fulfills the promise with `null`.
+
+Custom implementations of `PromiseInterface` must update their method signature
+from `resolve($value): void` to `resolve($value = null): void`.
+
 #### Collection Helper Inputs
 
 Promise collection helpers now require iterable inputs. Passing a single promise

--- a/src/Coroutine.php
+++ b/src/Coroutine.php
@@ -113,7 +113,7 @@ final class Coroutine implements PromiseInterface
         return $this->result->getState();
     }
 
-    public function resolve($value): void
+    public function resolve($value = null): void
     {
         $this->result->resolve($value);
     }

--- a/src/FulfilledPromise.php
+++ b/src/FulfilledPromise.php
@@ -76,7 +76,7 @@ class FulfilledPromise implements PromiseInterface
         return self::FULFILLED;
     }
 
-    public function resolve($value): void
+    public function resolve($value = null): void
     {
         if ($value !== $this->value) {
             throw new \LogicException('Cannot resolve a fulfilled promise');

--- a/src/Promise.php
+++ b/src/Promise.php
@@ -131,7 +131,7 @@ class Promise implements PromiseInterface
         }
     }
 
-    public function resolve($value): void
+    public function resolve($value = null): void
     {
         $this->settle(self::FULFILLED, $value);
     }

--- a/src/PromiseInterface.php
+++ b/src/PromiseInterface.php
@@ -67,13 +67,13 @@ interface PromiseInterface
     public function getState(): string;
 
     /**
-     * Resolve the promise with the given value.
+     * Resolve the promise with the given value, or with null if no value is given.
      *
-     * @param TValue|PromiseInterface<TValue, TReason> $value
+     * @param TValue|PromiseInterface<TValue, TReason>|null $value
      *
      * @throws \RuntimeException if the promise is already resolved.
      */
-    public function resolve($value): void;
+    public function resolve($value = null): void;
 
     /**
      * Reject the promise with the given reason.

--- a/src/RejectedPromise.php
+++ b/src/RejectedPromise.php
@@ -82,7 +82,7 @@ class RejectedPromise implements PromiseInterface
         return self::REJECTED;
     }
 
-    public function resolve($value): void
+    public function resolve($value = null): void
     {
         throw new \LogicException('Cannot resolve a rejected promise');
     }

--- a/tests/CoroutineTest.php
+++ b/tests/CoroutineTest.php
@@ -23,11 +23,8 @@ class CoroutineTest extends TestCase
 
     /**
      * @dataProvider promiseInterfaceMethodProvider
-     *
-     * @param string $method
-     * @param array  $args
      */
-    public function testShouldProxyPromiseMethodsToResultPromise($method, $args = []): void
+    public function testShouldProxyPromiseMethodsToResultPromise(string $method, array $args = []): void
     {
         $coroutine = new Coroutine(function () { yield 0; });
         $mockPromise = $this->createMock(PromiseInterface::class);
@@ -44,7 +41,7 @@ class CoroutineTest extends TestCase
         $coroutine->{$method}(...$args);
     }
 
-    public static function promiseInterfaceMethodProvider()
+    public static function promiseInterfaceMethodProvider(): array
     {
         return [
             ['then', [null, null]],
@@ -54,6 +51,23 @@ class CoroutineTest extends TestCase
             ['resolve', [null]],
             ['reject', [null]],
         ];
+    }
+
+    public function testShouldProxyResolveWithoutValueToResultPromiseAsNull(): void
+    {
+        $coroutine = new Coroutine(function () { yield 0; });
+        $mockPromise = $this->createMock(PromiseInterface::class);
+        $mockPromise->expects($this->once())->method('resolve')->with(null);
+
+        $resultPromiseProp = (new ReflectionClass(Coroutine::class))->getProperty('result');
+
+        if (PHP_VERSION_ID < 80100) {
+            $resultPromiseProp->setAccessible(true);
+        }
+
+        $resultPromiseProp->setValue($coroutine, $mockPromise);
+
+        $coroutine->resolve();
     }
 
     public function testShouldCancelResultPromiseAndOutsideCurrentPromise(): void

--- a/tests/FulfilledPromiseTest.php
+++ b/tests/FulfilledPromiseTest.php
@@ -58,6 +58,23 @@ class FulfilledPromiseTest extends TestCase
         $this->assertSame('foo', $p->wait());
     }
 
+    public function testCanResolveNullFulfilledPromiseWithoutValue(): void
+    {
+        $p = new FulfilledPromise(null);
+        $p->resolve();
+
+        $this->assertNull($p->wait());
+    }
+
+    public function testCannotResolveNonNullFulfilledPromiseWithoutValue(): void
+    {
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage('Cannot resolve a fulfilled promise');
+
+        $p = new FulfilledPromise('foo');
+        $p->resolve();
+    }
+
     public function testCannotResolveWithPromise(): void
     {
         $this->expectException(\InvalidArgumentException::class);

--- a/tests/NotPromiseInstance.php
+++ b/tests/NotPromiseInstance.php
@@ -26,7 +26,7 @@ class NotPromiseInstance extends Thennable implements PromiseInterface
         return $this->then($onRejected);
     }
 
-    public function resolve($value): void
+    public function resolve($value = null): void
     {
         $this->nextPromise->resolve($value);
     }

--- a/tests/PromiseTest.php
+++ b/tests/PromiseTest.php
@@ -36,6 +36,24 @@ class PromiseTest extends TestCase
         $this->assertSame('foo', $p->wait());
     }
 
+    public function testCanResolveWithoutValue(): void
+    {
+        $p = new Promise();
+        $p->resolve();
+
+        $this->assertTrue(P\Is::fulfilled($p));
+        $this->assertNull($p->wait());
+    }
+
+    public function testCanResolveWithoutValueRepeatedly(): void
+    {
+        $p = new Promise();
+        $p->resolve();
+        $p->resolve(null);
+
+        $this->assertNull($p->wait());
+    }
+
     public function testCannotRejectNonPendingPromise(): void
     {
         $this->expectException(\LogicException::class);
@@ -332,6 +350,24 @@ class PromiseTest extends TestCase
         $this->assertSame('foo', $carry);
     }
 
+    public function testResolveWithoutValueNotifiesCallbacksWithNull(): void
+    {
+        $p = new Promise();
+        $called = false;
+        $received = 'not called';
+
+        $p->then(function ($value) use (&$called, &$received): void {
+            $called = true;
+            $received = $value;
+        });
+
+        $p->resolve();
+        P\Utils::queue()->run();
+
+        $this->assertTrue($called);
+        $this->assertNull($received);
+    }
+
     public function testCreatesPromiseWhenFulfilledBeforeThen(): void
     {
         $p = new Promise();
@@ -344,6 +380,24 @@ class PromiseTest extends TestCase
         $this->assertNull($carry);
         P\Utils::queue()->run();
         $this->assertSame('foo', $carry);
+    }
+
+    public function testResolveWithoutValueBeforeThenNotifiesCallbackWithNull(): void
+    {
+        $p = new Promise();
+        $p->resolve();
+        $called = false;
+        $received = 'not called';
+
+        $p->then(function ($value) use (&$called, &$received): void {
+            $called = true;
+            $received = $value;
+        });
+
+        P\Utils::queue()->run();
+
+        $this->assertTrue($called);
+        $this->assertNull($received);
     }
 
     public function testCreatesPromiseWhenFulfilledWithNoCallback(): void

--- a/tests/RejectedPromiseTest.php
+++ b/tests/RejectedPromiseTest.php
@@ -45,6 +45,15 @@ class RejectedPromiseTest extends TestCase
         $p->resolve('bar');
     }
 
+    public function testCannotResolveWithoutValue(): void
+    {
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage('Cannot resolve a rejected promise');
+
+        $p = new RejectedPromise('foo');
+        $p->resolve();
+    }
+
     /**
      * @expectedExceptionMessage Cannot reject a rejected promise
      */

--- a/tests/Thennable.php
+++ b/tests/Thennable.php
@@ -20,7 +20,7 @@ class Thennable
         return $this->nextPromise->then($res, $rej);
     }
 
-    public function resolve($value): void
+    public function resolve($value = null): void
     {
         $this->nextPromise->resolve($value);
     }


### PR DESCRIPTION
Fixes #76. This allows `resolve()` to fulfill a promise with `null` when no value is provided. Custom `PromiseInterface` implementations must update `resolve($value): void` to `resolve($value = null): void`, as documented in `UPGRADING.md`.