### PR TITLE
[3.0] Add collection concurrency config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 ### Added
 
+- Added `concurrency` config support to `Utils::all()` and `Each::of()`
 - Added generic PHPDoc annotations to promise APIs
 - Allowed promises to be resolved without passing a value
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ for a general introduction to promises.
 - [Synchronous wait](#synchronous-wait)
 - [Cancellation](#cancellation)
 - [API](#api)
+  - [Promise Collection Helpers](#promise-collection-helpers)
   - [Promise](#promise)
   - [FulfilledPromise](#fulfilledpromise)
   - [RejectedPromise](#rejectedpromise)
@@ -308,6 +309,37 @@ of the promise.
 
 
 ## API
+
+### Promise Collection Helpers
+
+`Utils::all()` returns a promise that fulfills with all fulfillment values or
+rejects when any input promise rejects.
+
+For lazy iterables, pass `concurrency` to limit how many items are pulled from
+the iterable at one time:
+
+```php
+use GuzzleHttp\Promise\Utils;
+
+$promise = Utils::all($promises, false, ['concurrency' => 5]);
+```
+
+`Each::of()` accepts the same config when you need callbacks instead of
+collected values:
+
+```php
+use GuzzleHttp\Promise\Each;
+
+$promise = Each::of($promises, $onFulfilled, $onRejected, ['concurrency' => 5]);
+```
+
+This limits lazy promise creation. It does not throttle promises that have
+already been created or started. Callback config keys such as `fulfilled` and
+`rejected` are ignored by these wrappers; pass callbacks to `Each::of()`
+directly or use `EachPromise`.
+
+For HTTP request concurrency, use `GuzzleHttp\Pool` from `guzzlehttp/guzzle`.
+
 
 ### Promise
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -39,6 +39,21 @@ $promise = Each::ofLimit($singlePromise, 2);
 $promise = Each::ofLimit([$singlePromise], 2);
 ```
 
+#### Collection Helper Config
+
+`Utils::all()` and `Each::of()` now accept a trailing `$config` array with a
+`concurrency` option for lazy iterables:
+
+```php
+use GuzzleHttp\Promise\Utils;
+
+$promise = Utils::all($promises, false, ['concurrency' => 5]);
+```
+
+Only `concurrency` is honored by these wrappers. Callback config keys such as
+`fulfilled` and `rejected` are ignored; pass callbacks to `Each::of()` directly
+or use `EachPromise`.
+
 #### Generic PHPDoc Types
 
 `PromiseInterface`, `PromisorInterface`, and the built-in promise classes now

--- a/src/Each.php
+++ b/src/Each.php
@@ -19,6 +19,9 @@ final class Each
      * index, and the aggregate promise. The callback can invoke any necessary
      * side effects and choose to resolve or reject the aggregate if needed.
      *
+     * The config array accepts a concurrency option matching {@see ofLimit}.
+     * Other config keys are ignored by this wrapper.
+     *
      * @template TKey of array-key
      * @template TValue
      * @template TReason
@@ -26,18 +29,31 @@ final class Each
      * @param iterable<TKey, TValue|PromiseInterface<TValue, TReason>>             $iterable    Iterator or array to iterate over.
      * @param (callable(TValue, TKey, PromiseInterface<mixed, mixed>): void)|null  $onFulfilled
      * @param (callable(TReason, TKey, PromiseInterface<mixed, mixed>): void)|null $onRejected
+     * @param array{concurrency?: int|(callable(int): int)}                        $config      Configuration options.
      *
      * @return PromiseInterface<mixed, mixed>
      */
     public static function of(
         iterable $iterable,
         ?callable $onFulfilled = null,
-        ?callable $onRejected = null
+        ?callable $onRejected = null,
+        array $config = []
     ): PromiseInterface {
-        return (new EachPromise($iterable, [
-            'fulfilled' => $onFulfilled,
-            'rejected' => $onRejected,
-        ]))->promise();
+        $eachConfig = [];
+
+        if (null !== $onFulfilled) {
+            $eachConfig['fulfilled'] = $onFulfilled;
+        }
+
+        if (null !== $onRejected) {
+            $eachConfig['rejected'] = $onRejected;
+        }
+
+        if (isset($config['concurrency'])) {
+            $eachConfig['concurrency'] = $config['concurrency'];
+        }
+
+        return (new EachPromise($iterable, $eachConfig))->promise();
     }
 
     /**

--- a/src/Utils.php
+++ b/src/Utils.php
@@ -182,16 +182,20 @@ final class Utils
      * respective positions to the original array. If any promise in the array
      * rejects, the returned promise is rejected with the rejection reason.
      *
+     * The config array accepts a concurrency option for lazy iterables. Other
+     * config keys are ignored by this wrapper.
+     *
      * @template TKey of array-key
      * @template TValue
      * @template TReason
      *
      * @param iterable<TKey, TValue|PromiseInterface<TValue, TReason>> $promises  Promises or values.
      * @param bool                                                     $recursive If true, resolves new promises that might have been added to the stack during its own resolution.
+     * @param array{concurrency?: int|(callable(int): int)}            $config    Configuration options.
      *
      * @return PromiseInterface<array<TKey, TValue>, TReason|\Throwable>
      */
-    public static function all(iterable $promises, bool $recursive = false): PromiseInterface
+    public static function all(iterable $promises, bool $recursive = false, array $config = []): PromiseInterface
     {
         $results = [];
         $promise = Each::of(
@@ -203,7 +207,8 @@ final class Utils
                 if (Is::pending($aggregate)) {
                     $aggregate->reject($reason);
                 }
-            }
+            },
+            $config
         )->then(function () use (&$results) {
             ksort($results);
 
@@ -211,10 +216,10 @@ final class Utils
         });
 
         if (true === $recursive) {
-            $promise = $promise->then(function ($results) use ($recursive, &$promises) {
+            $promise = $promise->then(function ($results) use ($recursive, &$promises, $config) {
                 foreach ($promises as $promise) {
                     if (Is::pending($promise)) {
-                        return self::all($promises, $recursive);
+                        return self::all($promises, $recursive, $config);
                     }
                 }
 

--- a/tests/EachTest.php
+++ b/tests/EachTest.php
@@ -22,6 +22,71 @@ class EachTest extends TestCase
         $this->assertTrue(P\Is::fulfilled($aggregate));
     }
 
+    public function testEachOfLimitsConcurrencyWithConfig(): void
+    {
+        $created = 0;
+        $promises = [];
+        $results = [];
+
+        $iterable = static function () use (&$created, &$promises): \Generator {
+            foreach (['a', 'b', 'c'] as $key) {
+                ++$created;
+                $promises[$key] = new Promise();
+
+                yield $key => $promises[$key];
+            }
+        };
+
+        $aggregate = P\Each::of(
+            $iterable(),
+            function ($value, $key) use (&$results): void {
+                $results[$key] = $value;
+            },
+            null,
+            ['concurrency' => 1]
+        );
+
+        $this->assertSame(1, $created);
+
+        $promises['a']->resolve('A');
+        P\Utils::queue()->run();
+
+        $this->assertSame(2, $created);
+
+        $promises['b']->resolve('B');
+        P\Utils::queue()->run();
+
+        $this->assertSame(3, $created);
+
+        $promises['c']->resolve('C');
+
+        $this->assertNull($aggregate->wait());
+        $this->assertSame(['a' => 'A', 'b' => 'B', 'c' => 'C'], $results);
+    }
+
+    public function testEachOfIgnoresCallbackConfigKeys(): void
+    {
+        $results = [];
+
+        P\Each::of(
+            [new FulfilledPromise('a')],
+            function ($value) use (&$results): void {
+                $results[] = $value;
+            },
+            null,
+            [
+                'fulfilled' => static function (): void {
+                    throw new \RuntimeException('Should not be called.');
+                },
+                'rejected' => static function (): void {
+                    throw new \RuntimeException('Should not be called.');
+                },
+            ]
+        )->wait();
+
+        $this->assertSame(['a'], $results);
+    }
+
     public function testEachLimitAllRejectsOnFailure(): void
     {
         $p = [new FulfilledPromise('a'), new RejectedPromise('b')];

--- a/tests/UtilsTest.php
+++ b/tests/UtilsTest.php
@@ -92,6 +92,133 @@ class UtilsTest extends TestCase
         $this->assertSame(1, $counter);
     }
 
+    public function testAllLimitsConcurrencyForLazyIterable(): void
+    {
+        $created = 0;
+        $promises = [];
+
+        $iterable = static function () use (&$created, &$promises): \Generator {
+            foreach (['a', 'b', 'c', 'd'] as $key) {
+                ++$created;
+                $promises[$key] = new Promise();
+
+                yield $key => $promises[$key];
+            }
+        };
+
+        $aggregate = P\Utils::all($iterable(), false, ['concurrency' => 2]);
+
+        $this->assertSame(2, $created);
+
+        $promises['a']->resolve('A');
+        P\Utils::queue()->run();
+
+        $this->assertSame(3, $created);
+
+        $promises['b']->resolve('B');
+        P\Utils::queue()->run();
+
+        $this->assertSame(4, $created);
+
+        $promises['c']->resolve('C');
+        $promises['d']->resolve('D');
+
+        $this->assertSame([
+            'a' => 'A',
+            'b' => 'B',
+            'c' => 'C',
+            'd' => 'D',
+        ], $aggregate->wait());
+    }
+
+    public function testAllRejectsWithConcurrencyConfig(): void
+    {
+        $created = 0;
+        $promises = [];
+        $result = null;
+
+        $iterable = static function () use (&$created, &$promises): \Generator {
+            foreach (['a', 'b'] as $key) {
+                ++$created;
+                $promises[$key] = new Promise();
+
+                yield $key => $promises[$key];
+            }
+        };
+
+        $aggregate = P\Utils::all($iterable(), false, ['concurrency' => 1]);
+
+        $this->assertSame(1, $created);
+
+        $promises['a']->reject('fail');
+        P\Utils::queue()->run();
+
+        $aggregate->then(null, function ($reason) use (&$result): void {
+            $result = $reason;
+        });
+        P\Utils::queue()->run();
+
+        $this->assertSame('fail', $result);
+        $this->assertSame(1, $created);
+    }
+
+    public function testAllAcceptsCallableConcurrencyConfig(): void
+    {
+        $pendingCounts = [];
+        $promises = [new Promise(), new Promise()];
+
+        $aggregate = P\Utils::all($promises, false, [
+            'concurrency' => static function (int $pendingCount) use (&$pendingCounts): int {
+                $pendingCounts[] = $pendingCount;
+
+                return 1;
+            },
+        ]);
+
+        $promises[0]->resolve('a');
+        P\Utils::queue()->run();
+
+        $promises[1]->resolve('b');
+
+        $this->assertSame(['a', 'b'], $aggregate->wait());
+        $this->assertSame([0, 0], $pendingCounts);
+    }
+
+    public function testAllIgnoresCallbackConfigKeys(): void
+    {
+        $result = P\Utils::all([new FulfilledPromise('a')], false, [
+            'fulfilled' => static function (): void {
+                throw new \RuntimeException('Should not be called.');
+            },
+            'rejected' => static function (): void {
+                throw new \RuntimeException('Should not be called.');
+            },
+        ])->wait();
+
+        $this->assertSame(['a'], $result);
+    }
+
+    public function testPromisesDynamicallyAddedToStackWithConcurrencyConfig(): void
+    {
+        $promises = new \ArrayIterator();
+        $counter = 0;
+        $promises['a'] = new FulfilledPromise('a');
+        $promises['b'] = $promise = new Promise(function () use (&$promise, &$promises, &$counter): void {
+            ++$counter;
+            $promise->resolve('b');
+            $promises['c'] = $subPromise = new Promise(function () use (&$subPromise): void {
+                $subPromise->resolve('c');
+            });
+        });
+
+        $result = P\Utils::all($promises, true, ['concurrency' => 1])->wait();
+
+        $this->assertCount(3, $promises);
+        $this->assertCount(3, $result);
+        $this->assertSame($result['c'], 'c');
+        $this->assertSame(1, $counter);
+    }
+
     public function testAllThrowsWhenAnyRejected(): void
     {
         $a = new Promise();


### PR DESCRIPTION
Fixes #147.

Adds a `concurrency` config option to `Utils::all()` and `Each::of()` for lazy promise collections.