### PR TITLE
[3.0] Add recursive settle support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 - Added `concurrency` config support to `Utils::all()` and `Each::of()`
 - Added generic PHPDoc annotations to promise APIs
+- Added recursive and `concurrency` config support to `Utils::settle()`
 - Allowed promises to be resolved without passing a value
 
 ### Changed
@@ -14,6 +15,10 @@
 - Changed `Utils::inspect()` to return actual rejection reasons
 - Changed late rejection callbacks to follow rejected promises
 - Require iterable inputs for promise collection helpers and `EachPromise`
+
+### Fixed
+
+- Fixed recursive `Utils::all()` handling of dynamically-added settled values and raw values
 
 ### Removed
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -41,18 +41,38 @@ $promise = Each::ofLimit([$singlePromise], 2);
 
 #### Collection Helper Config
 
-`Utils::all()` and `Each::of()` now accept a trailing `$config` array with a
-`concurrency` option for lazy iterables:
+`Utils::all()`, `Utils::settle()`, and `Each::of()` now accept a trailing
+`$config` array with a `concurrency` option for lazy iterables:
 
 ```php
 use GuzzleHttp\Promise\Utils;
 
 $promise = Utils::all($promises, false, ['concurrency' => 5]);
+$promise = Utils::settle($promises, false, ['concurrency' => 5]);
 ```
 
 Only `concurrency` is honored by these wrappers. Callback config keys such as
 `fulfilled` and `rejected` are ignored; pass callbacks to `Each::of()` directly
 or use `EachPromise`.
+
+#### Recursive Collection Helpers
+
+`Utils::settle()` now accepts a `$recursive` argument, matching `Utils::all()`:
+
+```php
+use GuzzleHttp\Promise\Utils;
+
+$promise = Utils::settle($promises, true);
+```
+
+When `$recursive` is true, collection helpers continue taking passes over the
+collection until no new entries are found and no visible promises remain pending.
+This is intended for rewindable mutable collections such as `ArrayIterator`.
+One-shot generators are not suitable for recursive mode because recursive passes
+need to iterate the collection again.
+
+Recursive `Utils::all()` now also detects dynamically-added settled values and
+raw values. Previously, recursive mode only checked for pending promises.
 
 #### Generic PHPDoc Types
 

--- a/src/Utils.php
+++ b/src/Utils.php
@@ -190,7 +190,7 @@ final class Utils
      * @template TReason
      *
      * @param iterable<TKey, TValue|PromiseInterface<TValue, TReason>> $promises  Promises or values.
-     * @param bool                                                     $recursive If true, resolves new promises that might have been added to the stack during its own resolution.
+     * @param bool                                                     $recursive If true, resolves newly-added entries until no unprocessed entries or pending promises remain.
      * @param array{concurrency?: int|(callable(int): int)}            $config    Configuration options.
      *
      * @return PromiseInterface<array<TKey, TValue>, TReason|\Throwable>
@@ -216,11 +216,9 @@ final class Utils
         });
 
         if (true === $recursive) {
-            $promise = $promise->then(function ($results) use ($recursive, &$promises, $config) {
-                foreach ($promises as $promise) {
-                    if (Is::pending($promise)) {
-                        return self::all($promises, $recursive, $config);
-                    }
+            $promise = $promise->then(function ($results) use (&$promises, $config) {
+                if (self::shouldRecurse($promises, $results)) {
+                    return self::all($promises, true, $config);
                 }
 
                 return $results;
@@ -307,32 +305,71 @@ final class Utils
      *
      * The returned promise is fulfilled with an array of inspection state arrays.
      *
+     * The config array accepts a concurrency option for lazy iterables. Other
+     * config keys are ignored by this wrapper.
+     *
      * @see inspect for the inspection state array format.
      *
      * @template TKey of array-key
      * @template TValue
      * @template TReason
      *
-     * @param iterable<TKey, TValue|PromiseInterface<TValue, TReason>> $promises Promises or values.
+     * @param iterable<TKey, TValue|PromiseInterface<TValue, TReason>> $promises  Promises or values.
+     * @param bool                                                     $recursive If true, settles newly-added entries until no unprocessed entries or pending promises remain.
+     * @param array{concurrency?: int|(callable(int): int)}            $config    Configuration options.
      *
-     * @return PromiseInterface<array<TKey, array{state: string, value?: TValue, reason?: TReason|\Throwable}>, \Throwable>
+     * @return PromiseInterface<array<TKey, array{state: PromiseInterface::FULFILLED, value: TValue}|array{state: PromiseInterface::REJECTED, reason: TReason|\Throwable}>, \Throwable>
      */
-    public static function settle(iterable $promises): PromiseInterface
+    public static function settle(iterable $promises, bool $recursive = false, array $config = []): PromiseInterface
     {
         $results = [];
 
-        return Each::of(
+        $promise = Each::of(
             $promises,
             function ($value, $idx) use (&$results): void {
                 $results[$idx] = ['state' => PromiseInterface::FULFILLED, 'value' => $value];
             },
             function ($reason, $idx) use (&$results): void {
                 $results[$idx] = ['state' => PromiseInterface::REJECTED, 'reason' => $reason];
-            }
+            },
+            $config
         )->then(function () use (&$results) {
             ksort($results);
 
             return $results;
         });
+
+        if (true === $recursive) {
+            $promise = $promise->then(function ($results) use (&$promises, $config) {
+                if (self::shouldRecurse($promises, $results)) {
+                    return self::settle($promises, true, $config);
+                }
+
+                return $results;
+            });
+        }
+
+        return $promise;
+    }
+
+    /**
+     * @template TKey of array-key
+     *
+     * @param iterable<TKey, mixed> $promises Promises or values.
+     * @param array<TKey, mixed>    $results  Results already collected for a pass.
+     */
+    private static function shouldRecurse(iterable $promises, array $results): bool
+    {
+        foreach ($promises as $key => $promise) {
+            if (!array_key_exists($key, $results)) {
+                return true;
+            }
+
+            if ($promise instanceof PromiseInterface && Is::pending($promise)) {
+                return true;
+            }
+        }
+
+        return false;
     }
 }

--- a/tests/UtilsTest.php
+++ b/tests/UtilsTest.php
@@ -92,6 +92,56 @@ class UtilsTest extends TestCase
         $this->assertSame(1, $counter);
     }
 
+    public function testAllRecursivelyHandlesRawValues(): void
+    {
+        $result = P\Utils::all(new \ArrayIterator(['a' => 1]), true)->wait();
+
+        $this->assertSame(['a' => 1], $result);
+    }
+
+    public function testAllRecursivelyIncludesDynamicallyAddedFulfilledPromise(): void
+    {
+        $promises = new \ArrayIterator();
+
+        $promises['a'] = $promise = new Promise(function () use (&$promise, $promises): void {
+            $promise->resolve('a');
+            $promises['b'] = new FulfilledPromise('b');
+        });
+
+        $result = P\Utils::all($promises, true)->wait();
+
+        $this->assertSame(['a' => 'a', 'b' => 'b'], $result);
+    }
+
+    public function testAllRecursivelyIncludesDynamicallyAddedRawValue(): void
+    {
+        $promises = new \ArrayIterator();
+
+        $promises['a'] = $promise = new Promise(function () use (&$promise, $promises): void {
+            $promise->resolve('a');
+            $promises['b'] = 'b';
+        });
+
+        $result = P\Utils::all($promises, true)->wait();
+
+        $this->assertSame(['a' => 'a', 'b' => 'b'], $result);
+    }
+
+    public function testAllRecursivelyRejectsDynamicallyAddedRejectedPromise(): void
+    {
+        $this->expectException(RejectionException::class);
+        $this->expectExceptionMessage('bad');
+
+        $promises = new \ArrayIterator();
+
+        $promises['a'] = $promise = new Promise(function () use (&$promise, $promises): void {
+            $promise->resolve('a');
+            $promises['b'] = new RejectedPromise('bad');
+        });
+
+        P\Utils::all($promises, true)->wait();
+    }
+
     public function testAllLimitsConcurrencyForLazyIterable(): void
     {
         $created = 0;
@@ -340,6 +390,186 @@ class UtilsTest extends TestCase
             ['state' => 'rejected', 'reason' => 'a'],
             ['state' => 'fulfilled', 'value' => 'b'],
             ['state' => 'fulfilled', 'value' => 'c'],
+        ], $result);
+    }
+
+    public function testSettleRecursivelyWaitsOnDynamicallyAddedPendingPromise(): void
+    {
+        $promises = new \ArrayIterator();
+        $waited = false;
+
+        $promises['a'] = $promise = new Promise(function () use (&$promise, $promises, &$waited): void {
+            $promise->resolve('a');
+
+            $promises['b'] = $next = new Promise(function () use (&$next, &$waited): void {
+                $waited = true;
+                $next->resolve('b');
+            });
+        });
+
+        $result = P\Utils::settle($promises, true)->wait();
+
+        $this->assertTrue($waited);
+        $this->assertSame([
+            'a' => ['state' => PromiseInterface::FULFILLED, 'value' => 'a'],
+            'b' => ['state' => PromiseInterface::FULFILLED, 'value' => 'b'],
+        ], $result);
+    }
+
+    public function testSettleRecursivelyIncludesDynamicallyAddedFulfilledPromise(): void
+    {
+        $promises = new \ArrayIterator();
+
+        $promises['a'] = $promise = new Promise(function () use (&$promise, $promises): void {
+            $promise->resolve('a');
+            $promises['b'] = new FulfilledPromise('b');
+        });
+
+        $result = P\Utils::settle($promises, true)->wait();
+
+        $this->assertSame([
+            'a' => ['state' => PromiseInterface::FULFILLED, 'value' => 'a'],
+            'b' => ['state' => PromiseInterface::FULFILLED, 'value' => 'b'],
+        ], $result);
+    }
+
+    public function testSettleRecursivelyIncludesDynamicallyAddedRejectedPromise(): void
+    {
+        $promises = new \ArrayIterator();
+
+        $promises['a'] = $promise = new Promise(function () use (&$promise, $promises): void {
+            $promise->resolve('a');
+            $promises['b'] = new RejectedPromise('bad');
+        });
+
+        $result = P\Utils::settle($promises, true)->wait();
+
+        $this->assertSame([
+            'a' => ['state' => PromiseInterface::FULFILLED, 'value' => 'a'],
+            'b' => ['state' => PromiseInterface::REJECTED, 'reason' => 'bad'],
+        ], $result);
+    }
+
+    public function testSettleRecursivelyHandlesRawValues(): void
+    {
+        $result = P\Utils::settle(new \ArrayIterator(['a' => 1]), true)->wait();
+
+        $this->assertSame([
+            'a' => ['state' => PromiseInterface::FULFILLED, 'value' => 1],
+        ], $result);
+    }
+
+    public function testSettleDoesNotRecurseByDefault(): void
+    {
+        $promises = new \ArrayIterator();
+
+        $promises['a'] = $promise = new Promise(function () use (&$promise, $promises): void {
+            $promise->resolve('a');
+            $promises['b'] = new FulfilledPromise('b');
+        });
+
+        $result = P\Utils::settle($promises)->wait();
+
+        $this->assertSame([
+            'a' => ['state' => PromiseInterface::FULFILLED, 'value' => 'a'],
+        ], $result);
+    }
+
+    public function testSettleRecursivelyHandlesRepeatedDynamicAdditions(): void
+    {
+        $promises = new \ArrayIterator();
+
+        $promises['a'] = $first = new Promise(function () use (&$first, $promises): void {
+            $first->resolve('a');
+
+            $promises['b'] = $second = new Promise(function () use (&$second, $promises): void {
+                $second->resolve('b');
+                $promises['c'] = new FulfilledPromise('c');
+            });
+        });
+
+        $result = P\Utils::settle($promises, true)->wait();
+
+        $this->assertSame([
+            'a' => ['state' => PromiseInterface::FULFILLED, 'value' => 'a'],
+            'b' => ['state' => PromiseInterface::FULFILLED, 'value' => 'b'],
+            'c' => ['state' => PromiseInterface::FULFILLED, 'value' => 'c'],
+        ], $result);
+    }
+
+    public function testSettleLimitsConcurrencyForLazyIterable(): void
+    {
+        $created = 0;
+        $promises = [];
+
+        $iterable = static function () use (&$created, &$promises): \Generator {
+            foreach (['a', 'b', 'c'] as $key) {
+                ++$created;
+                $promises[$key] = new Promise();
+
+                yield $key => $promises[$key];
+            }
+        };
+
+        $aggregate = P\Utils::settle($iterable(), false, ['concurrency' => 1]);
+
+        $this->assertSame(1, $created);
+
+        $promises['a']->resolve('A');
+        P\Utils::queue()->run();
+
+        $this->assertSame(2, $created);
+
+        $promises['b']->reject('B');
+        P\Utils::queue()->run();
+
+        $this->assertSame(3, $created);
+
+        $promises['c']->resolve('C');
+
+        $this->assertSame([
+            'a' => ['state' => PromiseInterface::FULFILLED, 'value' => 'A'],
+            'b' => ['state' => PromiseInterface::REJECTED, 'reason' => 'B'],
+            'c' => ['state' => PromiseInterface::FULFILLED, 'value' => 'C'],
+        ], $aggregate->wait());
+    }
+
+    public function testSettleIgnoresCallbackConfigKeys(): void
+    {
+        $result = P\Utils::settle([new FulfilledPromise('a')], false, [
+            'fulfilled' => static function (): void {
+                throw new \RuntimeException('Should not be called.');
+            },
+            'rejected' => static function (): void {
+                throw new \RuntimeException('Should not be called.');
+            },
+        ])->wait();
+
+        $this->assertSame([
+            ['state' => PromiseInterface::FULFILLED, 'value' => 'a'],
+        ], $result);
+    }
+
+    public function testSettleRecursivelyHandlesConcurrencyConfig(): void
+    {
+        $promises = new \ArrayIterator();
+        $counter = 0;
+        $promises['a'] = new FulfilledPromise('a');
+        $promises['b'] = $promise = new Promise(function () use (&$promise, $promises, &$counter): void {
+            ++$counter;
+            $promise->resolve('b');
+            $promises['c'] = $subPromise = new Promise(function () use (&$subPromise): void {
+                $subPromise->resolve('c');
+            });
+        });
+
+        $result = P\Utils::settle($promises, true, ['concurrency' => 1])->wait();
+
+        $this->assertSame(1, $counter);
+        $this->assertSame([
+            'a' => ['state' => PromiseInterface::FULFILLED, 'value' => 'a'],
+            'b' => ['state' => PromiseInterface::FULFILLED, 'value' => 'b'],
+            'c' => ['state' => PromiseInterface::FULFILLED, 'value' => 'c'],
         ], $result);
     }
 


### PR DESCRIPTION
Adds recursive support to Utils::settle() and lets it use the collection concurrency config.

The recursive scan is shared with Utils::all(), fixing dynamically-added settled values and raw values in recursive all() calls.

Recursive mode is documented for rewindable mutable iterables such as ArrayIterator.