### PR TITLE
Clarify Promises 3 upgrade guide

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -4,6 +4,11 @@ Guzzle Promises Upgrade Guide
 2.x to 3.0
 ----------
 
+Guzzle Promises 3.0 is a major release that raises the minimum PHP version,
+updates promise and collection helper signatures, tightens collection helper
+inputs, improves recursive collection behavior, and clarifies rejection
+inspection and late rejection callback behavior.
+
 #### PHP Version and Dependencies
 
 Guzzle Promises 3.0 requires PHP `^7.4 || ^8.0`. Guzzle Promises 2.x supported
@@ -11,6 +16,9 @@ PHP `^7.2.5 || ^8.0`.
 
 If your application still supports PHP 7.2 or 7.3, continue using Guzzle
 Promises 2.x until your minimum PHP version is raised.
+
+Guzzle Promises has no runtime package dependencies, so there are no runtime
+package dependency changes beyond PHP.
 
 #### Optional Promise Resolution Values
 
@@ -83,28 +91,6 @@ This is intended for rewindable mutable collections such as `ArrayIterator`.
 If recursive mode needs to observe values added after the first pass, replace
 one-shot generators with a rewindable mutable collection.
 
-#### Generic PHPDoc Types
-
-`PromiseInterface`, `PromisorInterface`, and the built-in promise classes now
-include generic PHPDoc annotations for static analysis tools. The first template
-type represents the fulfillment value and the second represents the rejection
-reason. This is a static-analysis-only change and does not alter runtime
-behavior:
-
-```php
-use GuzzleHttp\Promise\PromiseInterface;
-
-/** @var PromiseInterface<string, \Throwable> */
-$promise = $factory->createPromise();
-
-$value = $promise->wait();
-```
-
-Code that uses unparameterized promise types continues to work and is treated as
-`PromiseInterface<mixed, mixed>`. If your project implements promise interfaces,
-extends promise classes, or has stricter static analysis, you may need to update
-your PHPDoc annotations to include the generic value and reason types.
-
 #### Promise Inspection
 
 `Utils::inspect()` and `Utils::inspectAll()` now return the actual rejection
@@ -148,6 +134,28 @@ $promise->then(null, function ($reason): void {
 
 Utils::queue()->run();
 ```
+
+#### Generic PHPDoc Types
+
+`PromiseInterface`, `PromisorInterface`, and the built-in promise classes now
+include generic PHPDoc annotations for static analysis tools. The first template
+type represents the fulfillment value and the second represents the rejection
+reason. This is a static-analysis-only change and does not alter runtime
+behavior:
+
+```php
+use GuzzleHttp\Promise\PromiseInterface;
+
+/** @var PromiseInterface<string, \Throwable> */
+$promise = $factory->createPromise();
+
+$value = $promise->wait();
+```
+
+Code that uses unparameterized promise types continues to work and is treated as
+`PromiseInterface<mixed, mixed>`. If your project implements promise interfaces,
+extends promise classes, or has stricter static analysis, you may need to update
+your PHPDoc annotations to include the generic value and reason types.
 
 1.x to 2.0
 ----------

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -31,6 +31,29 @@ Custom implementations of `PromiseInterface`, and subclasses that override
 their method signature from `resolve($value): void` to
 `resolve($value = null): void`.
 
+#### Generic PHPDoc Types
+
+`PromiseInterface`, `PromisorInterface`, and the built-in promise classes now
+include generic PHPDoc annotations for static analysis tools. The first template
+type represents the fulfillment value and the second represents the rejection
+reason. This is a static-analysis-only change and does not alter runtime
+behavior, but projects with stricter static analysis may see new or different
+diagnostics:
+
+```php
+use GuzzleHttp\Promise\PromiseInterface;
+
+/** @var PromiseInterface<string, \Throwable> */
+$promise = $factory->createPromise();
+
+$value = $promise->wait();
+```
+
+Code that uses unparameterized promise types continues to work and is treated as
+`PromiseInterface<mixed, mixed>`. If your project implements promise interfaces,
+extends promise classes, or has stricter static analysis, you may need to update
+your PHPDoc annotations to include the generic value and reason types.
+
 #### Collection Helper Inputs
 
 Promise collection helpers now require iterable inputs. Passing a single promise
@@ -70,29 +93,6 @@ $promise = Utils::settle($promises, false, ['concurrency' => 5]);
 Only `concurrency` is honored by these helper config arrays. Callback config
 keys such as `fulfilled` and `rejected` are ignored; pass callbacks to
 `Each::of()` directly or use `EachPromise`.
-
-#### Generic PHPDoc Types
-
-`PromiseInterface`, `PromisorInterface`, and the built-in promise classes now
-include generic PHPDoc annotations for static analysis tools. The first template
-type represents the fulfillment value and the second represents the rejection
-reason. This is a static-analysis-only change and does not alter runtime
-behavior, but projects with stricter static analysis may see new or different
-diagnostics:
-
-```php
-use GuzzleHttp\Promise\PromiseInterface;
-
-/** @var PromiseInterface<string, \Throwable> */
-$promise = $factory->createPromise();
-
-$value = $promise->wait();
-```
-
-Code that uses unparameterized promise types continues to work and is treated as
-`PromiseInterface<mixed, mixed>`. If your project implements promise interfaces,
-extends promise classes, or has stricter static analysis, you may need to update
-your PHPDoc annotations to include the generic value and reason types.
 
 #### Recursive Collection Helpers
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -5,9 +5,10 @@ Guzzle Promises Upgrade Guide
 ----------
 
 Guzzle Promises 3.0 is a major release that raises the minimum PHP version,
-updates promise and collection helper signatures, tightens collection helper
-inputs, improves recursive collection behavior, and clarifies rejection
-inspection and late rejection callback behavior.
+updates promise and collection helper signatures, adds generic PHPDoc types for
+static analyzers, tightens collection helper inputs, improves recursive
+collection behavior, and clarifies rejection inspection and late rejection
+callback behavior.
 
 #### PHP Version and Dependencies
 
@@ -69,6 +70,29 @@ $promise = Utils::settle($promises, false, ['concurrency' => 5]);
 Only `concurrency` is honored by these helper config arrays. Callback config
 keys such as `fulfilled` and `rejected` are ignored; pass callbacks to
 `Each::of()` directly or use `EachPromise`.
+
+#### Generic PHPDoc Types
+
+`PromiseInterface`, `PromisorInterface`, and the built-in promise classes now
+include generic PHPDoc annotations for static analysis tools. The first template
+type represents the fulfillment value and the second represents the rejection
+reason. This is a static-analysis-only change and does not alter runtime
+behavior, but projects with stricter static analysis may see new or different
+diagnostics:
+
+```php
+use GuzzleHttp\Promise\PromiseInterface;
+
+/** @var PromiseInterface<string, \Throwable> */
+$promise = $factory->createPromise();
+
+$value = $promise->wait();
+```
+
+Code that uses unparameterized promise types continues to work and is treated as
+`PromiseInterface<mixed, mixed>`. If your project implements promise interfaces,
+extends promise classes, or has stricter static analysis, you may need to update
+your PHPDoc annotations to include the generic value and reason types.
 
 #### Recursive Collection Helpers
 
@@ -134,28 +158,6 @@ $promise->then(null, function ($reason): void {
 
 Utils::queue()->run();
 ```
-
-#### Generic PHPDoc Types
-
-`PromiseInterface`, `PromisorInterface`, and the built-in promise classes now
-include generic PHPDoc annotations for static analysis tools. The first template
-type represents the fulfillment value and the second represents the rejection
-reason. This is a static-analysis-only change and does not alter runtime
-behavior:
-
-```php
-use GuzzleHttp\Promise\PromiseInterface;
-
-/** @var PromiseInterface<string, \Throwable> */
-$promise = $factory->createPromise();
-
-$value = $promise->wait();
-```
-
-Code that uses unparameterized promise types continues to work and is treated as
-`PromiseInterface<mixed, mixed>`. If your project implements promise interfaces,
-extends promise classes, or has stricter static analysis, you may need to update
-your PHPDoc annotations to include the generic value and reason types.
 
 1.x to 2.0
 ----------


### PR DESCRIPTION
This updates the Promises 3.0 upgrade guide so it starts with a summary and then the PHP dependency change. It also makes clear that there are no runtime package dependency changes beyond PHP, moves the generic PHPDoc notes higher for static-analysis users, and keeps the collection helper sections together.