### PR TITLE
Make static helper classes non-instantiable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 - Changed `Utils::inspect()` to return actual rejection reasons
 - Changed late rejection callbacks to follow rejected promises
+- Made static helper classes non-instantiable
 - Require iterable inputs for promise collection helpers and `EachPromise`
 
 ### Fixed

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -159,6 +159,12 @@ $promise->then(null, function ($reason): void {
 Utils::queue()->run();
 ```
 
+#### Non-instantiable Helper Classes
+
+Static helper classes such as `Create`, `Each`, `Is`, and `Utils` now have
+private constructors. Replace any accidental instantiation with static method
+calls.
+
 1.x to 2.0
 ----------
 

--- a/src/Create.php
+++ b/src/Create.php
@@ -6,6 +6,10 @@ namespace GuzzleHttp\Promise;
 
 final class Create
 {
+    private function __construct()
+    {
+    }
+
     /**
      * Creates a promise for a value if the value is not a promise.
      *

--- a/src/Each.php
+++ b/src/Each.php
@@ -6,6 +6,10 @@ namespace GuzzleHttp\Promise;
 
 final class Each
 {
+    private function __construct()
+    {
+    }
+
     /**
      * Given an iterator that yields promises or values, returns a promise that
      * is fulfilled with a null value when the iterator has been consumed or

--- a/src/Is.php
+++ b/src/Is.php
@@ -6,6 +6,10 @@ namespace GuzzleHttp\Promise;
 
 final class Is
 {
+    private function __construct()
+    {
+    }
+
     /**
      * Returns true if a promise is pending.
      */

--- a/src/Utils.php
+++ b/src/Utils.php
@@ -6,6 +6,10 @@ namespace GuzzleHttp\Promise;
 
 final class Utils
 {
+    private function __construct()
+    {
+    }
+
     /**
      * Get the global task queue used for promise resolution.
      *


### PR DESCRIPTION
This makes the Promises static helper classes non-instantiable. The affected classes only expose static helper methods, so callers should use static method calls.