### PR TITLE
Improve promise PHPDoc typing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 ### Added
 
 - Added `concurrency` config support to `Utils::all()` and `Each::of()`
-- Added generic PHPDoc annotations to promise APIs
+- Added generic PHPDoc annotations to promise APIs and collection callbacks
 - Added recursive and `concurrency` config support to `Utils::settle()`
 - Allowed promises to be resolved without passing a value
 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ why the promise cannot be fulfilled.
 
 ### Callbacks
 
-Callbacks are registered with the `then` method by providing an optional 
+Callbacks are registered with the `then` method by providing an optional
 `$onFulfilled` followed by an optional `$onRejected` function.
 
 
@@ -310,6 +310,11 @@ of the promise.
 
 ## API
 
+Promise APIs are documented for static analysis as
+`PromiseInterface<TValue, TReason>`. `TValue` is the fulfillment value type and
+`TReason` is the rejection reason type. This typing is PHPDoc-only and does not
+change runtime behavior.
+
 ### Promise Collection Helpers
 
 `Utils::all()` returns a promise that fulfills with all fulfillment values or
@@ -325,7 +330,10 @@ $promise = Utils::all($promises, false, ['concurrency' => 5]);
 ```
 
 `Each::of()` accepts the same config when you need callbacks instead of
-collected values:
+collected values. Fulfillment callbacks receive the fulfilled value, the
+iterable key, and the aggregate promise. Rejection callbacks receive the
+rejection reason, the iterable key, and the aggregate promise. Callbacks may
+declare only the arguments they use, and their return values are ignored.
 
 ```php
 use GuzzleHttp\Promise\Each;
@@ -367,18 +375,22 @@ assert('waited' === $promise->wait());
 
 A promise has the following methods:
 
-- `then(callable $onFulfilled, callable $onRejected) : PromiseInterface`
-  
-  Appends fulfillment and rejection handlers to the promise, and returns a new promise resolving to the return value of the called handler.
+- `then(?callable $onFulfilled = null, ?callable $onRejected = null) : PromiseInterface`
+
+  Appends fulfillment and rejection handlers to the promise, and returns a new
+  promise resolving to the return value of the called handler. If a handler is
+  omitted, the original fulfillment value or rejection reason is forwarded.
 
 - `otherwise(callable $onRejected) : PromiseInterface`
-  
-  Appends a rejection handler callback to the promise, and returns a new promise resolving to the return value of the callback if it is called, or to its original fulfillment value if the promise is instead fulfilled.
+
+  Appends a rejection handler callback to the promise, and returns a new promise
+  resolving to the return value of the callback if it is called, or to its
+  original fulfillment value if the promise is instead fulfilled.
 
 - `wait($unwrap = true) : mixed`
 
   Synchronously waits on the promise to complete.
-  
+
   `$unwrap` controls whether or not the value of the promise is returned for a
   fulfilled promise or if an exception is thrown if the promise is rejected.
   This is set to `true` by default.

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -54,6 +54,11 @@ Code that uses unparameterized promise types continues to work and is treated as
 extends promise classes, or has stricter static analysis, you may need to update
 your PHPDoc annotations to include the generic value and reason types.
 
+The 3.0 PHPDoc now preserves promise-chain fulfillment and rejection types more
+precisely through `then()` and `otherwise()`. Collection callbacks are also
+documented with optional trailing key and aggregate-promise arguments, so
+callbacks may declare only the arguments they use.
+
 #### Collection Helper Inputs
 
 Promise collection helpers now require iterable inputs. Passing a single promise

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -52,12 +52,11 @@ $value = $promise->wait();
 Code that uses unparameterized promise types continues to work and is treated as
 `PromiseInterface<mixed, mixed>`. If your project implements promise interfaces,
 extends promise classes, or has stricter static analysis, you may need to update
-your PHPDoc annotations to include the generic value and reason types.
-
-The 3.0 PHPDoc now preserves promise-chain fulfillment and rejection types more
-precisely through `then()` and `otherwise()`. Collection callbacks are also
-documented with optional trailing key and aggregate-promise arguments, so
-callbacks may declare only the arguments they use.
+your PHPDoc annotations to include the generic value and reason types. The
+expanded PHPDoc also preserves promise-chain fulfillment and rejection types more
+precisely through `then()` and `otherwise()`, and documents collection callbacks
+with value or reason, key, and aggregate-promise arguments so callbacks may
+declare only the arguments they use.
 
 #### Collection Helper Inputs
 

--- a/src/Coroutine.php
+++ b/src/Coroutine.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace GuzzleHttp\Promise;
 
 use Generator;
-use Throwable;
 
 /**
  * Creates a promise that is resolved using a generator that yields values or
@@ -74,7 +73,7 @@ final class Coroutine implements PromiseInterface
         });
         try {
             $this->nextCoroutine($this->generator->current());
-        } catch (Throwable $throwable) {
+        } catch (\Throwable $throwable) {
             $this->result->reject($throwable);
         }
     }
@@ -91,6 +90,17 @@ final class Coroutine implements PromiseInterface
         return new self($generatorFn);
     }
 
+    /**
+     * @template TFulfilledValue = never
+     * @template TFulfilledReason = never
+     * @template TRejectedValue = never
+     * @template TRejectedReason = never
+     *
+     * @param (callable(TValue): (TFulfilledValue|PromiseInterface<TFulfilledValue, TFulfilledReason>))|null $onFulfilled Invoked when the promise fulfills.
+     * @param (callable(TReason): (TRejectedValue|PromiseInterface<TRejectedValue, TRejectedReason>))|null   $onRejected  Invoked when the promise is rejected.
+     *
+     * @return PromiseInterface<($onFulfilled is null ? TValue : TFulfilledValue)|($onRejected is null ? never : TRejectedValue), ($onFulfilled is null ? never : TFulfilledReason|\Throwable)|($onRejected is null ? TReason : TRejectedReason|\Throwable)>
+     */
     public function then(
         ?callable $onFulfilled = null,
         ?callable $onRejected = null
@@ -98,6 +108,14 @@ final class Coroutine implements PromiseInterface
         return $this->result->then($onFulfilled, $onRejected);
     }
 
+    /**
+     * @template TRejectedValue = never
+     * @template TRejectedReason = never
+     *
+     * @param callable(TReason): (TRejectedValue|PromiseInterface<TRejectedValue, TRejectedReason>) $onRejected Invoked when the promise is rejected.
+     *
+     * @return PromiseInterface<TValue|TRejectedValue, TRejectedReason|\Throwable>
+     */
     public function otherwise(callable $onRejected): PromiseInterface
     {
         return $this->result->otherwise($onRejected);
@@ -152,7 +170,7 @@ final class Coroutine implements PromiseInterface
             } else {
                 $this->result->resolve($value);
             }
-        } catch (Throwable $throwable) {
+        } catch (\Throwable $throwable) {
             $this->result->reject($throwable);
         }
     }
@@ -168,7 +186,7 @@ final class Coroutine implements PromiseInterface
             $nextYield = $this->generator->throw(Create::exceptionFor($reason));
             // The throw was caught, so keep iterating on the coroutine
             $this->nextCoroutine($nextYield);
-        } catch (Throwable $throwable) {
+        } catch (\Throwable $throwable) {
             $this->result->reject($throwable);
         }
     }

--- a/src/Each.php
+++ b/src/Each.php
@@ -30,10 +30,10 @@ final class Each
      * @template TValue
      * @template TReason
      *
-     * @param iterable<TKey, TValue|PromiseInterface<TValue, TReason>>             $iterable    Iterator or array to iterate over.
-     * @param (callable(TValue, TKey, PromiseInterface<mixed, mixed>): void)|null  $onFulfilled
-     * @param (callable(TReason, TKey, PromiseInterface<mixed, mixed>): void)|null $onRejected
-     * @param array{concurrency?: int|(callable(int): int)}                        $config      Configuration options.
+     * @param iterable<TKey, TValue|PromiseInterface<TValue, TReason>>                $iterable    Iterator or array to iterate over.
+     * @param (callable(TValue, TKey=, PromiseInterface<mixed, mixed>=): mixed)|null  $onFulfilled
+     * @param (callable(TReason, TKey=, PromiseInterface<mixed, mixed>=): mixed)|null $onRejected
+     * @param array{concurrency?: int|(callable(int): int)}                           $config      Configuration options.
      *
      * @return PromiseInterface<mixed, mixed>
      */
@@ -72,10 +72,10 @@ final class Each
      * @template TValue
      * @template TReason
      *
-     * @param iterable<TKey, TValue|PromiseInterface<TValue, TReason>>             $iterable
-     * @param int|(callable(int): int)                                             $concurrency
-     * @param (callable(TValue, TKey, PromiseInterface<mixed, mixed>): void)|null  $onFulfilled
-     * @param (callable(TReason, TKey, PromiseInterface<mixed, mixed>): void)|null $onRejected
+     * @param iterable<TKey, TValue|PromiseInterface<TValue, TReason>>                $iterable
+     * @param int|(callable(int): int)                                                $concurrency
+     * @param (callable(TValue, TKey=, PromiseInterface<mixed, mixed>=): mixed)|null  $onFulfilled
+     * @param (callable(TReason, TKey=, PromiseInterface<mixed, mixed>=): mixed)|null $onRejected
      *
      * @return PromiseInterface<mixed, mixed>
      */
@@ -85,11 +85,7 @@ final class Each
         ?callable $onFulfilled = null,
         ?callable $onRejected = null
     ): PromiseInterface {
-        return (new EachPromise($iterable, [
-            'fulfilled' => $onFulfilled,
-            'rejected' => $onRejected,
-            'concurrency' => $concurrency,
-        ]))->promise();
+        return self::of($iterable, $onFulfilled, $onRejected, ['concurrency' => $concurrency]);
     }
 
     /**
@@ -101,9 +97,9 @@ final class Each
      * @template TValue
      * @template TReason
      *
-     * @param iterable<TKey, TValue|PromiseInterface<TValue, TReason>>            $iterable
-     * @param int|(callable(int): int)                                            $concurrency
-     * @param (callable(TValue, TKey, PromiseInterface<mixed, mixed>): void)|null $onFulfilled
+     * @param iterable<TKey, TValue|PromiseInterface<TValue, TReason>>               $iterable
+     * @param int|(callable(int): int)                                               $concurrency
+     * @param (callable(TValue, TKey=, PromiseInterface<mixed, mixed>=): mixed)|null $onFulfilled
      *
      * @return PromiseInterface<mixed, mixed>
      */
@@ -116,8 +112,10 @@ final class Each
             $iterable,
             $concurrency,
             $onFulfilled,
-            function ($reason, $idx, PromiseInterface $aggregate): void {
-                $aggregate->reject($reason);
+            function ($reason, $idx = null, ?PromiseInterface $aggregate = null): void {
+                if (null !== $aggregate) {
+                    $aggregate->reject($reason);
+                }
             }
         );
     }

--- a/src/Each.php
+++ b/src/Each.php
@@ -30,10 +30,10 @@ final class Each
      * @template TValue
      * @template TReason
      *
-     * @param iterable<TKey, TValue|PromiseInterface<TValue, TReason>>                $iterable    Iterator or array to iterate over.
-     * @param (callable(TValue, TKey=, PromiseInterface<mixed, mixed>=): mixed)|null  $onFulfilled
-     * @param (callable(TReason, TKey=, PromiseInterface<mixed, mixed>=): mixed)|null $onRejected
-     * @param array{concurrency?: int|(callable(int): int)}                           $config      Configuration options.
+     * @param iterable<TKey, TValue|PromiseInterface<TValue, TReason>>              $iterable    Iterator or array to iterate over.
+     * @param (callable(TValue, TKey, PromiseInterface<mixed, mixed>): mixed)|null  $onFulfilled
+     * @param (callable(TReason, TKey, PromiseInterface<mixed, mixed>): mixed)|null $onRejected
+     * @param array{concurrency?: int|(callable(int): int)}                         $config      Configuration options.
      *
      * @return PromiseInterface<mixed, mixed>
      */
@@ -72,10 +72,10 @@ final class Each
      * @template TValue
      * @template TReason
      *
-     * @param iterable<TKey, TValue|PromiseInterface<TValue, TReason>>                $iterable
-     * @param int|(callable(int): int)                                                $concurrency
-     * @param (callable(TValue, TKey=, PromiseInterface<mixed, mixed>=): mixed)|null  $onFulfilled
-     * @param (callable(TReason, TKey=, PromiseInterface<mixed, mixed>=): mixed)|null $onRejected
+     * @param iterable<TKey, TValue|PromiseInterface<TValue, TReason>>              $iterable
+     * @param int|(callable(int): int)                                              $concurrency
+     * @param (callable(TValue, TKey, PromiseInterface<mixed, mixed>): mixed)|null  $onFulfilled
+     * @param (callable(TReason, TKey, PromiseInterface<mixed, mixed>): mixed)|null $onRejected
      *
      * @return PromiseInterface<mixed, mixed>
      */
@@ -97,9 +97,9 @@ final class Each
      * @template TValue
      * @template TReason
      *
-     * @param iterable<TKey, TValue|PromiseInterface<TValue, TReason>>               $iterable
-     * @param int|(callable(int): int)                                               $concurrency
-     * @param (callable(TValue, TKey=, PromiseInterface<mixed, mixed>=): mixed)|null $onFulfilled
+     * @param iterable<TKey, TValue|PromiseInterface<TValue, TReason>>             $iterable
+     * @param int|(callable(int): int)                                             $concurrency
+     * @param (callable(TValue, TKey, PromiseInterface<mixed, mixed>): mixed)|null $onFulfilled
      *
      * @return PromiseInterface<mixed, mixed>
      */
@@ -112,10 +112,8 @@ final class Each
             $iterable,
             $concurrency,
             $onFulfilled,
-            function ($reason, $idx = null, ?PromiseInterface $aggregate = null): void {
-                if (null !== $aggregate) {
-                    $aggregate->reject($reason);
-                }
+            function ($reason, $idx, PromiseInterface $aggregate): void {
+                $aggregate->reject($reason);
             }
         );
     }

--- a/src/EachPromise.php
+++ b/src/EachPromise.php
@@ -29,10 +29,10 @@ class EachPromise implements PromisorInterface
     /** @var (callable(int): int)|int|null */
     private $concurrency;
 
-    /** @var (callable(TValue, TKey=, PromiseInterface<mixed, mixed>=): mixed)|null */
+    /** @var (callable(TValue, TKey, PromiseInterface<mixed, mixed>): mixed)|null */
     private $onFulfilled;
 
-    /** @var (callable(TReason, TKey=, PromiseInterface<mixed, mixed>=): mixed)|null */
+    /** @var (callable(TReason, TKey, PromiseInterface<mixed, mixed>): mixed)|null */
     private $onRejected;
 
     /** @var Promise<mixed, mixed>|null */
@@ -60,8 +60,8 @@ class EachPromise implements PromisorInterface
      *
      * @param iterable<TKey, TValue|PromiseInterface<TValue, TReason>> $iterable Promises or values to iterate.
      * @param array{
-     *     fulfilled?: callable(TValue, TKey=, PromiseInterface<mixed, mixed>=): mixed,
-     *     rejected?: callable(TReason, TKey=, PromiseInterface<mixed, mixed>=): mixed,
+     *     fulfilled?: callable(TValue, TKey, PromiseInterface<mixed, mixed>): mixed,
+     *     rejected?: callable(TReason, TKey, PromiseInterface<mixed, mixed>): mixed,
      *     concurrency?: int|(callable(int): int)
      * } $config Configuration options
      */

--- a/src/EachPromise.php
+++ b/src/EachPromise.php
@@ -29,10 +29,10 @@ class EachPromise implements PromisorInterface
     /** @var (callable(int): int)|int|null */
     private $concurrency;
 
-    /** @var (callable(TValue, TKey, PromiseInterface<mixed, mixed>): void)|null */
+    /** @var (callable(TValue, TKey=, PromiseInterface<mixed, mixed>=): mixed)|null */
     private $onFulfilled;
 
-    /** @var (callable(TReason, TKey, PromiseInterface<mixed, mixed>): void)|null */
+    /** @var (callable(TReason, TKey=, PromiseInterface<mixed, mixed>=): mixed)|null */
     private $onRejected;
 
     /** @var Promise<mixed, mixed>|null */
@@ -60,8 +60,8 @@ class EachPromise implements PromisorInterface
      *
      * @param iterable<TKey, TValue|PromiseInterface<TValue, TReason>> $iterable Promises or values to iterate.
      * @param array{
-     *     fulfilled?: callable(TValue, TKey, PromiseInterface<mixed, mixed>): void,
-     *     rejected?: callable(TReason, TKey, PromiseInterface<mixed, mixed>): void,
+     *     fulfilled?: callable(TValue, TKey=, PromiseInterface<mixed, mixed>=): mixed,
+     *     rejected?: callable(TReason, TKey=, PromiseInterface<mixed, mixed>=): mixed,
      *     concurrency?: int|(callable(int): int)
      * } $config Configuration options
      */

--- a/src/FulfilledPromise.php
+++ b/src/FulfilledPromise.php
@@ -36,6 +36,17 @@ class FulfilledPromise implements PromiseInterface
         $this->value = $value;
     }
 
+    /**
+     * @template TFulfilledValue = never
+     * @template TFulfilledReason = never
+     * @template TRejectedValue = never
+     * @template TRejectedReason = never
+     *
+     * @param (callable(TValue): (TFulfilledValue|PromiseInterface<TFulfilledValue, TFulfilledReason>))|null $onFulfilled Invoked when the promise fulfills.
+     * @param (callable(TReason): (TRejectedValue|PromiseInterface<TRejectedValue, TRejectedReason>))|null   $onRejected  Invoked when the promise is rejected.
+     *
+     * @return ($onFulfilled is null ? self<TValue, TReason> : PromiseInterface<TFulfilledValue, TFulfilledReason|\Throwable>)
+     */
     public function then(
         ?callable $onFulfilled = null,
         ?callable $onRejected = null
@@ -61,6 +72,11 @@ class FulfilledPromise implements PromiseInterface
         return $p;
     }
 
+    /**
+     * @param callable(TReason): mixed $onRejected Invoked when the promise is rejected.
+     *
+     * @return self<TValue, TReason>
+     */
     public function otherwise(callable $onRejected): PromiseInterface
     {
         return $this->then(null, $onRejected);

--- a/src/Promise.php
+++ b/src/Promise.php
@@ -81,7 +81,6 @@ class Promise implements PromiseInterface
 
         // It's either cancelled or rejected, so return a rejected promise
         // and immediately invoke any callbacks.
-        /** @var RejectedPromise<TValue, TReason> $rejection */
         $rejection = Create::rejectionFor($this->result);
 
         /** @var PromiseInterface<($onFulfilled is null ? TValue : TFulfilledValue)|($onRejected is null ? never : TRejectedValue), ($onFulfilled is null ? never : TFulfilledReason|\Throwable)|($onRejected is null ? TReason : TRejectedReason|\Throwable)> $promise */

--- a/src/Promise.php
+++ b/src/Promise.php
@@ -49,7 +49,15 @@ class Promise implements PromiseInterface
     }
 
     /**
-     * @return PromiseInterface<mixed, mixed>
+     * @template TFulfilledValue = never
+     * @template TFulfilledReason = never
+     * @template TRejectedValue = never
+     * @template TRejectedReason = never
+     *
+     * @param (callable(TValue): (TFulfilledValue|PromiseInterface<TFulfilledValue, TFulfilledReason>))|null $onFulfilled Invoked when the promise fulfills.
+     * @param (callable(TReason): (TRejectedValue|PromiseInterface<TRejectedValue, TRejectedReason>))|null   $onRejected  Invoked when the promise is rejected.
+     *
+     * @return PromiseInterface<($onFulfilled is null ? TValue : TFulfilledValue)|($onRejected is null ? never : TRejectedValue), ($onFulfilled is null ? never : TFulfilledReason|\Throwable)|($onRejected is null ? TReason : TRejectedReason|\Throwable)>
      */
     public function then(
         ?callable $onFulfilled = null,
@@ -73,11 +81,23 @@ class Promise implements PromiseInterface
 
         // It's either cancelled or rejected, so return a rejected promise
         // and immediately invoke any callbacks.
+        /** @var RejectedPromise<TValue, TReason> $rejection */
         $rejection = Create::rejectionFor($this->result);
 
-        return $onRejected ? $rejection->then(null, $onRejected) : $rejection;
+        /** @var PromiseInterface<($onFulfilled is null ? TValue : TFulfilledValue)|($onRejected is null ? never : TRejectedValue), ($onFulfilled is null ? never : TFulfilledReason|\Throwable)|($onRejected is null ? TReason : TRejectedReason|\Throwable)> $promise */
+        $promise = $onRejected ? $rejection->then(null, $onRejected) : $rejection;
+
+        return $promise;
     }
 
+    /**
+     * @template TRejectedValue = never
+     * @template TRejectedReason = never
+     *
+     * @param callable(TReason): (TRejectedValue|PromiseInterface<TRejectedValue, TRejectedReason>) $onRejected Invoked when the promise is rejected.
+     *
+     * @return PromiseInterface<TValue|TRejectedValue, TRejectedReason|\Throwable>
+     */
     public function otherwise(callable $onRejected): PromiseInterface
     {
         return $this->then(null, $onRejected);

--- a/src/RejectedPromise.php
+++ b/src/RejectedPromise.php
@@ -36,6 +36,17 @@ class RejectedPromise implements PromiseInterface
         $this->reason = $reason;
     }
 
+    /**
+     * @template TFulfilledValue = never
+     * @template TFulfilledReason = never
+     * @template TRejectedValue = never
+     * @template TRejectedReason = never
+     *
+     * @param (callable(TValue): (TFulfilledValue|PromiseInterface<TFulfilledValue, TFulfilledReason>))|null $onFulfilled Invoked when the promise fulfills.
+     * @param (callable(TReason): (TRejectedValue|PromiseInterface<TRejectedValue, TRejectedReason>))|null   $onRejected  Invoked when the promise is rejected.
+     *
+     * @return ($onRejected is null ? self<TValue, TReason> : PromiseInterface<TRejectedValue, TRejectedReason|\Throwable>)
+     */
     public function then(
         ?callable $onFulfilled = null,
         ?callable $onRejected = null
@@ -63,6 +74,14 @@ class RejectedPromise implements PromiseInterface
         return $p;
     }
 
+    /**
+     * @template TRejectedValue = never
+     * @template TRejectedReason = never
+     *
+     * @param callable(TReason): (TRejectedValue|PromiseInterface<TRejectedValue, TRejectedReason>) $onRejected Invoked when the promise is rejected.
+     *
+     * @return PromiseInterface<TRejectedValue, TRejectedReason|\Throwable>
+     */
     public function otherwise(callable $onRejected): PromiseInterface
     {
         return $this->then(null, $onRejected);

--- a/src/TaskQueue.php
+++ b/src/TaskQueue.php
@@ -18,6 +18,7 @@ namespace GuzzleHttp\Promise;
 class TaskQueue implements TaskQueueInterface
 {
     private bool $enableShutdown = true;
+    /** @var list<callable(): void> */
     private array $queue = [];
 
     public function __construct(bool $withShutdown = true)
@@ -40,6 +41,9 @@ class TaskQueue implements TaskQueueInterface
         return !$this->queue;
     }
 
+    /**
+     * @param callable(): void $task
+     */
     public function add(callable $task): void
     {
         $this->queue[] = $task;
@@ -48,7 +52,7 @@ class TaskQueue implements TaskQueueInterface
     public function run(): void
     {
         while ($task = array_shift($this->queue)) {
-            /** @var callable $task */
+            /** @var callable(): void $task */
             $task();
         }
     }

--- a/src/TaskQueueInterface.php
+++ b/src/TaskQueueInterface.php
@@ -14,6 +14,8 @@ interface TaskQueueInterface
     /**
      * Adds a task to the queue that will be executed the next time run is
      * called.
+     *
+     * @param callable(): void $task
      */
     public function add(callable $task): void;
 

--- a/src/Utils.php
+++ b/src/Utils.php
@@ -139,7 +139,7 @@ final class Utils
      *
      * @param iterable<TKey, PromiseInterface<TValue, TReason>> $promises Traversable of promises to wait upon.
      *
-     * @return array<TKey, array{state: string, value?: TValue, reason?: TReason|\Throwable}>
+     * @return array<TKey, array{state: PromiseInterface::FULFILLED, value: TValue}|array{state: PromiseInterface::REJECTED, reason: TReason|\Throwable}|array{state: PromiseInterface::PENDING}>
      */
     public static function inspectAll(iterable $promises): array
     {
@@ -204,11 +204,11 @@ final class Utils
         $results = [];
         $promise = Each::of(
             $promises,
-            function ($value, $idx) use (&$results): void {
+            function ($value, $idx = null) use (&$results): void {
                 $results[$idx] = $value;
             },
-            function ($reason, $idx, PromiseInterface $aggregate): void {
-                if (Is::pending($aggregate)) {
+            function ($reason, $idx = null, ?PromiseInterface $aggregate = null): void {
+                if (null !== $aggregate && Is::pending($aggregate)) {
                     $aggregate->reject($reason);
                 }
             },
@@ -249,17 +249,17 @@ final class Utils
      * @param int                                                $count    Total number of promises.
      * @param iterable<TValue|PromiseInterface<TValue, TReason>> $promises Promises or values.
      *
-     * @return PromiseInterface<list<mixed>, mixed>
+     * @return PromiseInterface<list<TValue>, \Throwable>
      */
     public static function some(int $count, iterable $promises): PromiseInterface
     {
         $results = [];
         $rejections = [];
 
-        return Each::of(
+        $promise = Each::of(
             $promises,
-            function ($value, $idx, PromiseInterface $p) use (&$results, $count): void {
-                if (Is::settled($p)) {
+            function ($value, $idx = null, ?PromiseInterface $p = null) use (&$results, $count): void {
+                if (null === $p || Is::settled($p)) {
                     return;
                 }
                 $results[$idx] = $value;
@@ -283,6 +283,9 @@ final class Utils
                 return array_values($results);
             }
         );
+
+        /** @var PromiseInterface<list<TValue>, \Throwable> $promise */
+        return $promise;
     }
 
     /**
@@ -294,7 +297,7 @@ final class Utils
      *
      * @param iterable<TValue|PromiseInterface<TValue, TReason>> $promises Promises or values.
      *
-     * @return PromiseInterface<mixed, mixed>
+     * @return PromiseInterface<TValue, \Throwable>
      */
     public static function any(iterable $promises): PromiseInterface
     {
@@ -330,10 +333,10 @@ final class Utils
 
         $promise = Each::of(
             $promises,
-            function ($value, $idx) use (&$results): void {
+            function ($value, $idx = null) use (&$results): void {
                 $results[$idx] = ['state' => PromiseInterface::FULFILLED, 'value' => $value];
             },
-            function ($reason, $idx) use (&$results): void {
+            function ($reason, $idx = null) use (&$results): void {
                 $results[$idx] = ['state' => PromiseInterface::REJECTED, 'reason' => $reason];
             },
             $config

--- a/src/Utils.php
+++ b/src/Utils.php
@@ -204,11 +204,11 @@ final class Utils
         $results = [];
         $promise = Each::of(
             $promises,
-            function ($value, $idx = null) use (&$results): void {
+            function ($value, $idx) use (&$results): void {
                 $results[$idx] = $value;
             },
-            function ($reason, $idx = null, ?PromiseInterface $aggregate = null): void {
-                if (null !== $aggregate && Is::pending($aggregate)) {
+            function ($reason, $idx, PromiseInterface $aggregate): void {
+                if (Is::pending($aggregate)) {
                     $aggregate->reject($reason);
                 }
             },
@@ -258,8 +258,8 @@ final class Utils
 
         $promise = Each::of(
             $promises,
-            function ($value, $idx = null, ?PromiseInterface $p = null) use (&$results, $count): void {
-                if (null === $p || Is::settled($p)) {
+            function ($value, $idx, PromiseInterface $p) use (&$results, $count): void {
+                if (Is::settled($p)) {
                     return;
                 }
                 $results[$idx] = $value;
@@ -333,10 +333,10 @@ final class Utils
 
         $promise = Each::of(
             $promises,
-            function ($value, $idx = null) use (&$results): void {
+            function ($value, $idx) use (&$results): void {
                 $results[$idx] = ['state' => PromiseInterface::FULFILLED, 'value' => $value];
             },
-            function ($reason, $idx = null) use (&$results): void {
+            function ($reason, $idx) use (&$results): void {
                 $results[$idx] = ['state' => PromiseInterface::REJECTED, 'reason' => $reason];
             },
             $config

--- a/tests/NotPromiseInstance.php
+++ b/tests/NotPromiseInstance.php
@@ -7,6 +7,9 @@ namespace GuzzleHttp\Promise\Tests;
 use GuzzleHttp\Promise\Promise;
 use GuzzleHttp\Promise\PromiseInterface;
 
+/**
+ * @implements PromiseInterface<mixed, mixed>
+ */
 class NotPromiseInstance extends Thennable implements PromiseInterface
 {
     private Promise $nextPromise;
@@ -16,11 +19,22 @@ class NotPromiseInstance extends Thennable implements PromiseInterface
         $this->nextPromise = new Promise();
     }
 
+    /**
+     * @param (callable(mixed): mixed)|null $res
+     * @param (callable(mixed): mixed)|null $rej
+     *
+     * @return PromiseInterface<mixed, mixed>
+     */
     public function then(?callable $res = null, ?callable $rej = null): PromiseInterface
     {
         return $this->nextPromise->then($res, $rej);
     }
 
+    /**
+     * @param callable(mixed): mixed $onRejected
+     *
+     * @return PromiseInterface<mixed, mixed>
+     */
     public function otherwise(callable $onRejected): PromiseInterface
     {
         return $this->then($onRejected);

--- a/tests/Thennable.php
+++ b/tests/Thennable.php
@@ -16,6 +16,12 @@ class Thennable
         $this->nextPromise = new Promise();
     }
 
+    /**
+     * @param (callable(mixed): mixed)|null $res
+     * @param (callable(mixed): mixed)|null $rej
+     *
+     * @return PromiseInterface<mixed, mixed>
+     */
     public function then(?callable $res = null, ?callable $rej = null): PromiseInterface
     {
         return $this->nextPromise->then($res, $rej);


### PR DESCRIPTION
This expands the PHPDoc for promise chaining, settled promise specializations, collection callbacks, and task queue callables. It also updates the README, upgrade guide, changelog, and test helpers to match the improved static-analysis surface.