### PR TITLE
Add promise utility continuation return type

### DIFF
--- a/src/Utils.php
+++ b/src/Utils.php
@@ -271,7 +271,10 @@ final class Utils
                 $rejections[] = $reason;
             }
         )->then(
-            function () use (&$results, &$rejections, $count) {
+            /**
+             * @return list<TValue>
+             */
+            function () use (&$results, &$rejections, $count): array {
                 if (count($results) !== $count) {
                     throw new AggregateException(
                         'Not enough promises to fulfill count',


### PR DESCRIPTION
This adds a native array return type to the Utils::some() fulfillment continuation while preserving its generic list PHPDoc.