### PR TITLE
Clarify throwable rejection behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,8 +230,8 @@ $promise = new Promise(function () use (&$promise) {
 echo $promise->wait(); // outputs "foo"
 ```
 
-If an exception is encountered while invoking the wait function of a promise,
-the promise is rejected with the exception and the exception is thrown.
+If a throwable is encountered while invoking the wait function of a promise,
+the promise is rejected with the throwable and the throwable is thrown.
 
 ```php
 $promise = new Promise(function () use (&$promise) {
@@ -250,8 +250,8 @@ $promise->resolve('foo');
 echo $promise->wait(); // outputs "foo"
 ```
 
-Calling `wait` on a promise that has been rejected will throw an exception. If
-the rejection reason is an instance of `\Exception` the reason is thrown.
+Calling `wait` on a promise that has been rejected will throw. If the rejection
+reason is an instance of `\Throwable` the reason is thrown.
 Otherwise, a `GuzzleHttp\Promise\RejectionException` is thrown and the reason
 can be obtained by calling the `getReason` method of the exception.
 

--- a/tests/FulfilledPromiseTest.php
+++ b/tests/FulfilledPromiseTest.php
@@ -114,6 +114,23 @@ class FulfilledPromiseTest extends TestCase
         }
     }
 
+    public function testReturnsNewRejectedWhenOnFulfilledThrowsError(): void
+    {
+        $p = new FulfilledPromise('a');
+        $error = new \Error('b');
+        $p2 = $p->then(static function () use ($error): void {
+            throw $error;
+        });
+
+        $this->assertNotSame($p, $p2);
+        try {
+            $p2->wait();
+            $this->fail('Expected Error');
+        } catch (\Error $e) {
+            $this->assertSame($error, $e);
+        }
+    }
+
     public function testOtherwiseIsSugarForRejections(): void
     {
         $c = null;

--- a/tests/PromiseTest.php
+++ b/tests/PromiseTest.php
@@ -124,6 +124,21 @@ class PromiseTest extends TestCase
         $p->wait();
     }
 
+    public function testThrowsWhenUnwrapIsRejectedWithError(): void
+    {
+        $error = new \Error('foo');
+        $p = new Promise(function () use (&$p, $error): void {
+            $p->reject($error);
+        });
+
+        try {
+            $p->wait();
+            $this->fail('Expected Error');
+        } catch (\Error $e) {
+            $this->assertSame($error, $e);
+        }
+    }
+
     public function testDoesNotUnwrapExceptionsWhenDisabled(): void
     {
         $p = new Promise(function () use (&$p): void {
@@ -144,6 +159,22 @@ class PromiseTest extends TestCase
             $p->wait();
             $this->fail();
         } catch (\UnexpectedValueException $e) {
+            $this->assertTrue(P\Is::rejected($p));
+        }
+    }
+
+    public function testRejectsSelfWhenWaitThrowsError(): void
+    {
+        $error = new \Error('foo');
+        $p = new Promise(function () use ($error): void {
+            throw $error;
+        });
+
+        try {
+            $p->wait();
+            $this->fail('Expected Error');
+        } catch (\Error $e) {
+            $this->assertSame($error, $e);
             $this->assertTrue(P\Is::rejected($p));
         }
     }

--- a/tests/RejectedPromiseTest.php
+++ b/tests/RejectedPromiseTest.php
@@ -122,6 +122,23 @@ class RejectedPromiseTest extends TestCase
         }
     }
 
+    public function testReturnsNewRejectedWhenOnRejectedThrowsError(): void
+    {
+        $p = new RejectedPromise('a');
+        $error = new \Error('b');
+        $p2 = $p->then(null, static function () use ($error): void {
+            throw $error;
+        });
+
+        $this->assertNotSame($p, $p2);
+        try {
+            $p2->wait();
+            $this->fail('Expected Error');
+        } catch (\Error $e) {
+            $this->assertSame($error, $e);
+        }
+    }
+
     public function testWaitingIsNoOp(): void
     {
         $p = new RejectedPromise('a');


### PR DESCRIPTION
This documents the existing promise behavior that thrown or rejected Throwable instances are preserved as rejection reasons and rethrown unchanged when a promise is unwrapped. The tests now cover Error from wait functions and promise callbacks so the distinction is explicit, while the README wording has been updated from exception-only language to match the implementation.