### PR TITLE
Document throwable rejection behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,8 +227,8 @@ $promise = new Promise(function () use (&$promise) {
 echo $promise->wait(); // outputs "foo"
 ```
 
-If an exception is encountered while invoking the wait function of a promise,
-the promise is rejected with the exception and the exception is thrown.
+If a throwable is encountered while invoking the wait function of a promise,
+the promise is rejected with the throwable and the throwable is thrown.
 
 ```php
 $promise = new Promise(function () use (&$promise) {
@@ -247,8 +247,8 @@ $promise->resolve('foo');
 echo $promise->wait(); // outputs "foo"
 ```
 
-Calling `wait` on a promise that has been rejected will throw an exception. If
-the rejection reason is an instance of `\Exception` the reason is thrown.
+Calling `wait` on a promise that has been rejected will throw. If the rejection
+reason is an instance of `\Throwable` the reason is thrown.
 Otherwise, a `GuzzleHttp\Promise\RejectionException` is thrown and the reason
 can be obtained by calling the `getReason` method of the exception.
 


### PR DESCRIPTION
This updates the README to match the existing 2.5 behavior that Throwable rejection reasons are thrown unchanged when a promise is unwrapped. The implementation already preserves Throwable instances, so this is a documentation-only backport of the wording change from the 3.0 branch.