### PR TITLE
Reject native PHP serialization of runtime promises

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 - Changed `Utils::inspect()` to return actual rejection reasons
 - Changed late rejection callbacks to follow rejected promises
+- Reject native PHP serialization of in-flight runtime objects
 - Made static helper classes non-instantiable
 - Require iterable inputs for promise collection helpers and `EachPromise`
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -21,6 +21,12 @@ Promises 2.x until your minimum PHP version is raised.
 Guzzle Promises has no runtime package dependencies, so there are no runtime
 package dependency changes beyond PHP.
 
+#### Native PHP Serialization Of Runtime Objects
+
+`Promise`, `TaskQueue`, `EachPromise`, and `Coroutine` no longer support native
+PHP `serialize()` or `unserialize()`. Persist application values instead of
+promise runtime state.
+
 #### Optional Promise Resolution Values
 
 `PromiseInterface::resolve()` now accepts an optional value. Calling `resolve()`

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -21,12 +21,6 @@ Promises 2.x until your minimum PHP version is raised.
 Guzzle Promises has no runtime package dependencies, so there are no runtime
 package dependency changes beyond PHP.
 
-#### Native PHP Serialization Of Runtime Objects
-
-`Promise`, `TaskQueue`, `EachPromise`, and `Coroutine` no longer support native
-PHP `serialize()` or `unserialize()`. Persist application values instead of
-promise runtime state.
-
 #### Optional Promise Resolution Values
 
 `PromiseInterface::resolve()` now accepts an optional value. Calling `resolve()`
@@ -174,6 +168,12 @@ Utils::queue()->run();
 Static helper classes such as `Create`, `Each`, `Is`, and `Utils` now have
 private constructors. Replace any accidental instantiation with static method
 calls.
+
+#### Native PHP Serialization of Runtime Objects
+
+`Promise`, `TaskQueue`, `EachPromise`, and `Coroutine` no longer support native
+PHP `serialize()` or `unserialize()`. Persist application values instead of
+promise runtime state.
 
 1.x to 2.0
 ----------

--- a/src/Coroutine.php
+++ b/src/Coroutine.php
@@ -45,6 +45,8 @@ use Generator;
  */
 final class Coroutine implements PromiseInterface
 {
+    use NonSerializableTrait;
+
     /**
      * @var PromiseInterface<mixed, mixed>|null
      */

--- a/src/EachPromise.php
+++ b/src/EachPromise.php
@@ -18,6 +18,8 @@ namespace GuzzleHttp\Promise;
  */
 class EachPromise implements PromisorInterface
 {
+    use NonSerializableTrait;
+
     /** @var array<int, PromiseInterface<mixed, mixed>>|null */
     private ?array $pending = [];
 

--- a/src/NonSerializableTrait.php
+++ b/src/NonSerializableTrait.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GuzzleHttp\Promise;
+
+/**
+ * @internal
+ */
+trait NonSerializableTrait
+{
+    public function __serialize(): array
+    {
+        throw new \LogicException(static::class.' should never be serialized');
+    }
+
+    public function __unserialize(array $data): void
+    {
+        throw new \LogicException(static::class.' should never be unserialized');
+    }
+}

--- a/src/Promise.php
+++ b/src/Promise.php
@@ -18,6 +18,8 @@ namespace GuzzleHttp\Promise;
  */
 class Promise implements PromiseInterface
 {
+    use NonSerializableTrait;
+
     /** @var self::PENDING|self::FULFILLED|self::REJECTED */
     private string $state = self::PENDING;
 

--- a/src/TaskQueue.php
+++ b/src/TaskQueue.php
@@ -17,6 +17,8 @@ namespace GuzzleHttp\Promise;
  */
 class TaskQueue implements TaskQueueInterface
 {
+    use NonSerializableTrait;
+
     private bool $enableShutdown = true;
     /** @var list<callable(): void> */
     private array $queue = [];


### PR DESCRIPTION
This rejects native PHP serialization for in-flight promise runtime objects and documents the new behavior. Settled promise wrappers remain unchanged.