### PR TITLE
Drop redundant parentheses around the handler callable type hints

### DIFF
--- a/src/Promise.php
+++ b/src/Promise.php
@@ -35,7 +35,7 @@ class Promise implements PromiseInterface
     /** @var list<Promise<mixed, mixed>>|null */
     private ?array $waitList = null;
 
-    /** @var list<array{0: PromiseInterface<mixed, mixed>, 1: (callable|null), 2: (callable|null)}>|null */
+    /** @var list<array{0: PromiseInterface<mixed, mixed>, 1: callable|null, 2: callable|null}>|null */
     private ?array $handlers = [];
 
     /**


### PR DESCRIPTION
The `$handlers` property documented its two callable slots as `(callable|null)`, but a bare `callable` is already an atomic type and needs no wrapping parentheses inside the array shape. This drops the redundant parentheses to match the unparenthesized bare-callable style used elsewhere, which parses to exactly the same type.