### PR TITLE
Fix recursive Utils::all() rejecting generator inputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # CHANGELOG
 
 
+## 2.5.1 - Unreleased
+
+### Fixed
+
+- Fixed recursive `Utils::all()` rejecting generator inputs
+
+
 ## 2.5.0 - 2026-06-02
 
 ### Deprecated

--- a/src/Utils.php
+++ b/src/Utils.php
@@ -168,6 +168,12 @@ final class Utils
 
         if (true === $recursive) {
             $promise = $promise->then(function ($results) use ($recursive, &$promises) {
+                // A consumed generator cannot be traversed again, so a
+                // recursive pass has nothing further to observe.
+                if ($promises instanceof \Generator) {
+                    return $results;
+                }
+
                 foreach ($promises as $promise) {
                     if (Is::pending($promise)) {
                         return self::all($promises, $recursive);

--- a/tests/UtilsTest.php
+++ b/tests/UtilsTest.php
@@ -92,6 +92,18 @@ class UtilsTest extends TestCase
         $this->assertSame(1, $counter);
     }
 
+    public function testAllRecursivelyHandlesGeneratorInput(): void
+    {
+        $gen = (static function (): \Generator {
+            yield 'a' => new FulfilledPromise(1);
+            yield 'b' => 2;
+        })();
+
+        $result = P\Utils::all($gen, true)->wait();
+
+        $this->assertSame(['a' => 1, 'b' => 2], $result);
+    }
+
     public function testAllThrowsWhenAnyRejected(): void
     {
         $a = new Promise();


### PR DESCRIPTION
The recursive mode of `Utils::all()` re-iterates the input collection after the first pass settles, looking for new entries and still-pending promises. A generator has already been consumed by that point, so the second traversal throws `Cannot traverse an already closed generator` and the aggregate promise rejects instead of returning the collected results. This returns the first-pass results when the input is a generator, since a consumed generator can have nothing further to observe, and adds a regression test. The changelog entry lands here on 2.5 as the oldest affected branch; the 3.0 branch receives the equivalent code fix in its own pull request.
