### PR TITLE
Skip recursive passes over consumed generator inputs

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -114,10 +114,11 @@ $promise = Utils::settle($promises, true);
 ```
 
 When `$recursive` is true, collection helpers continue taking passes over the
-collection until no new entries are found and no visible promises remain pending.
-This is intended for rewindable mutable collections such as `ArrayIterator`.
-If recursive mode needs to observe values added after the first pass, replace
-one-shot generators with a rewindable mutable collection.
+collection until no new entries are found and no visible promises remain
+pending. This is intended for rewindable mutable collections such as
+`ArrayIterator`. Generators are safe to pass, but they cannot be traversed
+again once consumed, so recursive mode degrades to a single pass; use a
+rewindable mutable collection when recursion needs to observe added values.
 
 #### Promise Inspection
 

--- a/src/Utils.php
+++ b/src/Utils.php
@@ -367,6 +367,12 @@ final class Utils
      */
     private static function shouldRecurse(iterable $promises, array $results): bool
     {
+        // A consumed generator cannot be traversed again, so a recursive
+        // pass has nothing further to observe.
+        if ($promises instanceof \Generator) {
+            return false;
+        }
+
         foreach ($promises as $key => $promise) {
             if (!array_key_exists($key, $results)) {
                 return true;

--- a/tests/CreateTest.php
+++ b/tests/CreateTest.php
@@ -55,4 +55,23 @@ class CreateTest extends TestCase
         $iter = new \ArrayIterator();
         $this->assertSame($iter, P\Create::iterFor($iter));
     }
+
+    public function testIterForIteratesIteratorAggregate(): void
+    {
+        $result = P\Create::iterFor(new \ArrayObject(['a' => 1, 'b' => 2]));
+
+        $this->assertSame(['a' => 1, 'b' => 2], iterator_to_array($result));
+    }
+
+    public function testIterForIteratesGeneratorBackedAggregate(): void
+    {
+        $aggregate = new class implements \IteratorAggregate {
+            public function getIterator(): \Generator
+            {
+                yield 'a' => 1;
+            }
+        };
+
+        $this->assertSame(['a' => 1], iterator_to_array(P\Create::iterFor($aggregate)));
+    }
 }

--- a/tests/UtilsTest.php
+++ b/tests/UtilsTest.php
@@ -99,6 +99,18 @@ class UtilsTest extends TestCase
         $this->assertSame(['a' => 1], $result);
     }
 
+    public function testAllRecursivelyHandlesGeneratorInput(): void
+    {
+        $gen = (static function (): \Generator {
+            yield 'a' => new FulfilledPromise(1);
+            yield 'b' => 2;
+        })();
+
+        $result = P\Utils::all($gen, true)->wait();
+
+        $this->assertSame(['a' => 1, 'b' => 2], $result);
+    }
+
     public function testAllRecursivelyIncludesDynamicallyAddedFulfilledPromise(): void
     {
         $promises = new \ArrayIterator();
@@ -456,6 +468,21 @@ class UtilsTest extends TestCase
 
         $this->assertSame([
             'a' => ['state' => PromiseInterface::FULFILLED, 'value' => 1],
+        ], $result);
+    }
+
+    public function testSettleRecursivelyHandlesGeneratorInput(): void
+    {
+        $gen = (static function (): \Generator {
+            yield 'a' => new FulfilledPromise(1);
+            yield 'b' => new RejectedPromise('bad');
+        })();
+
+        $result = P\Utils::settle($gen, true)->wait();
+
+        $this->assertSame([
+            'a' => ['state' => PromiseInterface::FULFILLED, 'value' => 1],
+            'b' => ['state' => PromiseInterface::REJECTED, 'reason' => 'bad'],
         ], $result);
     }
 


### PR DESCRIPTION
This applies the recursive generator fix from #223 to the 3.0 branch, where the shared `shouldRecurse()` helper re-iterates the input after the first pass and therefore also breaks the new recursive `Utils::settle()`, which is documented to always fulfill. Skipping recursion for generators makes both helpers return their first-pass results, since a consumed generator can have nothing further to observe, and the upgrade guide now states that recursive mode degrades to a single pass for generators instead of implying they must be replaced.

This also adds the missing `Create::iterFor()` tests covering the `IteratorAggregate` recursion introduced in 3.0. There is no changelog entry here because the 2.5.1 entry from #223 will arrive with the changelog merge-up.
