### PR TITLE
Fix docs cross-links and document IteratorAggregate handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - Reject native PHP serialization of in-flight runtime objects
 - Made static helper classes non-instantiable
 - Require iterable inputs for promise collection helpers and `EachPromise`
+- Iterate `IteratorAggregate` inputs to collection helpers instead of treating them as a single value
 
 ### Fixed
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -77,6 +77,20 @@ $promise = Each::ofLimit($singlePromise, 2);
 $promise = Each::ofLimit([$singlePromise], 2);
 ```
 
+`IteratorAggregate` inputs are now iterated via `getIterator()`. In 2.x an
+aggregate was treated as a single value and produced one result; in 3.0 its
+entries are consumed individually.
+
+```php
+use GuzzleHttp\Promise\Utils;
+
+$aggregate = new \ArrayObject([$promiseA, $promiseB]);
+
+// 2.x: one result — the ArrayObject itself
+// 3.0: two results — the fulfillment values of $promiseA and $promiseB
+$promise = Utils::all($aggregate);
+```
+
 #### Collection Helper Signatures
 
 `Utils::all()`, `Utils::settle()`, and `Each::of()` now accept trailing optional

--- a/docs/implementation-notes.md
+++ b/docs/implementation-notes.md
@@ -66,6 +66,6 @@ GuzzleHttp\Promise\Utils::queue()->run();
 
 ## Related
 
-- [Quick Start](quickstart.md)
+- [Quick Start](promise-quick-start.md)
 - [Promise API](promise-api.md)
-- [Promise Interoperability](interop.md)
+- [Promise Interoperability](promise-interoperability.md)

--- a/docs/promise-api.md
+++ b/docs/promise-api.md
@@ -166,7 +166,7 @@ the promise being waited on.
 
 ## Related
 
-- [Quick Start](quickstart.md)
-- [Promise Interoperability](interop.md)
-- [Implementation Notes](implementation.md)
+- [Quick Start](promise-quick-start.md)
+- [Promise Interoperability](promise-interoperability.md)
+- [Implementation Notes](implementation-notes.md)
 - [Upgrade Guide](../UPGRADING.md)

--- a/docs/promise-interoperability.md
+++ b/docs/promise-interoperability.md
@@ -73,6 +73,6 @@ $loop->addPeriodicTimer(0.01, [$queue, 'run']);
 
 ## Related
 
-- [Quick Start](quickstart.md)
+- [Quick Start](promise-quick-start.md)
 - [Promise API](promise-api.md)
-- [Implementation Notes](implementation.md)
+- [Implementation Notes](implementation-notes.md)

--- a/docs/promise-quick-start.md
+++ b/docs/promise-quick-start.md
@@ -314,6 +314,6 @@ cancel function settles the promise first.
 ## Related
 
 - [Promise API](promise-api.md)
-- [Promise Interoperability](interop.md)
-- [Implementation Notes](implementation.md)
+- [Promise Interoperability](promise-interoperability.md)
+- [Implementation Notes](implementation-notes.md)
 - [Upgrade Guide](../UPGRADING.md)


### PR DESCRIPTION
The four documentation pages added on this branch cross-reference each other with filenames that were renamed before merge, so nine of their Related links point at `quickstart.md`, `interop.md`, and `implementation.md` instead of the real `promise-quick-start.md`, `promise-interoperability.md`, and `implementation-notes.md`. This fixes all nine links.

It also documents the `Create::iterFor()` behavior change for `IteratorAggregate` inputs, which 3.0 now iterates via `getIterator()` where 2.x treated them as a single value. The 2.x deprecation never fired for aggregates because they already satisfy `is_iterable()`, so collection helper results change silently for such inputs; this adds the changelog entry and a before/after example to the Collection Helper Inputs section of the upgrade guide.
