### PR TITLE
Cover serialization refusal and clean fixture

### DIFF
--- a/tests/NonSerializableTraitTest.php
+++ b/tests/NonSerializableTraitTest.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GuzzleHttp\Promise\Tests;
+
+use GuzzleHttp\Promise\Coroutine;
+use GuzzleHttp\Promise\EachPromise;
+use GuzzleHttp\Promise\Promise;
+use GuzzleHttp\Promise\TaskQueue;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \GuzzleHttp\Promise\NonSerializableTrait
+ */
+class NonSerializableTraitTest extends TestCase
+{
+    /**
+     * @dataProvider runtimeObjectProvider
+     */
+    public function testRuntimeObjectsCannotBeSerialized(object $object, string $class): void
+    {
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage($class.' should never be serialized');
+
+        serialize($object);
+    }
+
+    /**
+     * @dataProvider runtimeClassProvider
+     */
+    public function testRuntimeObjectsCannotBeUnserialized(string $class): void
+    {
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage($class.' should never be unserialized');
+
+        unserialize(sprintf('O:%d:"%s":0:{}', strlen($class), $class));
+    }
+
+    public static function runtimeObjectProvider(): array
+    {
+        return [
+            'promise' => [new Promise(), Promise::class],
+            'task-queue' => [new TaskQueue(false), TaskQueue::class],
+            'coroutine' => [new Coroutine(static function (): \Generator {
+                yield new Promise();
+            }), Coroutine::class],
+            'each-promise' => [new EachPromise([]), EachPromise::class],
+        ];
+    }
+
+    public static function runtimeClassProvider(): array
+    {
+        return [
+            'promise' => [Promise::class],
+            'task-queue' => [TaskQueue::class],
+            'coroutine' => [Coroutine::class],
+            'each-promise' => [EachPromise::class],
+        ];
+    }
+}

--- a/tests/Thing2.php
+++ b/tests/Thing2.php
@@ -6,7 +6,6 @@ namespace GuzzleHttp\Promise\Tests;
 
 class Thing2 implements \JsonSerializable
 {
-    #[\ReturnTypeWillChange]
     public function jsonSerialize(): string
     {
         return '{}';


### PR DESCRIPTION
Native PHP serialization refusal is a documented 3.0 behavior wired through `NonSerializableTrait` into `Promise`, `TaskQueue`, `Coroutine`, and `EachPromise`, but no test covered it, so the guard could be weakened without any failure. This adds a provider-based test proving that `serialize()` and a crafted native object payload both throw the class-specific `LogicException`s for all four classes in both directions. It also removes a dead `#[\ReturnTypeWillChange]` attribute from the `Thing2` fixture, whose `jsonSerialize()` already declares a native `string` return type.