### PR TITLE
Wrap README prose to 80 columns

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,13 @@
 # Guzzle Promises
 
-`guzzlehttp/promises` is a small promise library used by Guzzle for asynchronous operations. It implements promise chaining, synchronous waiting, cancellation, and helpers for working with groups of promises.
+`guzzlehttp/promises` is a small promise library used by Guzzle for asynchronous
+operations. It implements promise chaining, synchronous waiting, cancellation,
+and helpers for working with groups of promises.
 
-Most application developers use this package through [`guzzlehttp/guzzle`](https://github.com/guzzle/guzzle/blob/8.0/README.md) by calling methods such as `requestAsync()`. Install this package directly when you need promise composition without the full HTTP client.
+Most application developers use this package through
+[`guzzlehttp/guzzle`](https://github.com/guzzle/guzzle/blob/8.0/README.md) by
+calling methods such as `requestAsync()`. Install this package directly when you
+need promise composition without the full HTTP client.
 
 ## Installation
 
@@ -45,7 +50,8 @@ You can wait for a promise to complete synchronously:
 $value = $promise->wait();
 ```
 
-When using Guzzle HTTP requests, asynchronous methods return `GuzzleHttp\Promise\PromiseInterface` instances:
+When using Guzzle HTTP requests, asynchronous methods return
+`GuzzleHttp\Promise\PromiseInterface` instances:
 
 ```php
 $promise = $client->requestAsync('GET', 'https://example.com');
@@ -63,14 +69,25 @@ $response = $promise->wait();
 
 ## Security
 
-If you discover a security vulnerability within this package, please send an email to security@tidelift.com. All security vulnerabilities will be promptly addressed. Please do not disclose security-related issues publicly until a fix has been announced. Please see [Security Policy](https://github.com/guzzle/promises/security/policy) for more information.
+If you discover a security vulnerability within this package, please send an
+email to security@tidelift.com. All security vulnerabilities will be promptly
+addressed. Please do not disclose security-related issues publicly until a fix
+has been announced. Please see
+[Security Policy](https://github.com/guzzle/promises/security/policy) for more
+information.
 
 ## License
 
-Guzzle is made available under the MIT License (MIT). Please see [License File](LICENSE) for more information.
+Guzzle is made available under the MIT License (MIT). Please see
+[License File](LICENSE) for more information.
 
 ## For Enterprise
 
 Available as part of the Tidelift Subscription
 
-The maintainers of Guzzle and thousands of other packages are working with Tidelift to deliver commercial support and maintenance for the open source dependencies you use to build your applications. Save time, reduce risk, and improve code health, while paying the maintainers of the exact dependencies you use. [Learn more.](https://tidelift.com/subscription/pkg/packagist-guzzlehttp-promises?utm_source=packagist-guzzlehttp-promises&utm_medium=referral&utm_campaign=enterprise&utm_term=repo)
+The maintainers of Guzzle and thousands of other packages are working with
+Tidelift to deliver commercial support and maintenance for the open source
+dependencies you use to build your applications. Save time, reduce risk, and
+improve code health, while paying the maintainers of the exact dependencies you
+use.
+[Learn more.](https://tidelift.com/subscription/pkg/packagist-guzzlehttp-promises?utm_source=packagist-guzzlehttp-promises&utm_medium=referral&utm_campaign=enterprise&utm_term=repo)


### PR DESCRIPTION
Reflows the README prose to a greedy 80-column width so the Markdown reads consistently and diffs stay small. Only line breaks change; no wording changes, and badges, code blocks, tables, and links are left untouched. There are no code changes.