### PR TITLE
Document the ASCII case folding requirement

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,6 +26,10 @@
   where they are accepted and we need to cast to a string, we should branch on
   `\is_finite($value)`, using `(string) $value` for the finite case and
   `\is_nan($value) ? 'NAN' : ($value > 0 ? 'INF' : '-INF')` otherwise.
+- Never call `strtolower()`, `strtoupper()`, `strcasecmp()`, `stripos()`, or
+  other locale-sensitive case functions; fold ASCII case with
+  `strtr($value, 'ABCDEFGHIJKLMNOPQRSTUVWXYZ', 'abcdefghijklmnopqrstuvwxyz')`
+  and its inverse instead.
 - Changes in behavior need a `CHANGELOG.md` entry in the unreleased section of
   the target branch and an `UPGRADING.md` note when the behavior differs between
   major versions.


### PR DESCRIPTION
PHP's case-conversion functions honor `LC_CTYPE` before PHP 8.2, and the ecosystem-wide sweep converting every call site to locale-independent ASCII folds (guzzle/psr7#851 and siblings) added a corresponding AGENTS.md rule to the packages it touched. This adds the same rule here preventively so future code follows it, phrased with an inline `strtr()` fold since this package does not depend on guzzlehttp/psr7 and its helpers.