### PR TITLE
Default the impossible settled promise generics to never

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 
 ## 3.0.1 - Upcoming
 
+### Changed
+
+- Changed the default `TReason` of `FulfilledPromise` and `Create::promiseFor()` to `never`
+- Changed the default `TValue` of `RejectedPromise` and `Create::rejectionFor()` to `never`
+
 ### Fixed
 
 - Fixed `EachPromise` abandoning its aggregate when the pending window drains unsettled

--- a/src/Create.php
+++ b/src/Create.php
@@ -20,7 +20,7 @@ final class Create
      *
      * @param TValue|TPromise $value Promise or value.
      *
-     * @return ($value is PromiseInterface ? TPromise : FulfilledPromise<TValue, mixed>)
+     * @return ($value is PromiseInterface ? TPromise : FulfilledPromise<TValue, never>)
      */
     public static function promiseFor($value): PromiseInterface
     {
@@ -46,7 +46,7 @@ final class Create
      * promise for plain reasons.
      *
      * @template TReason
-     * @template TValue = mixed
+     * @template TValue = never
      * @template TPromise of PromiseInterface<mixed, mixed> = PromiseInterface<mixed, mixed>
      *
      * @param TReason|TPromise $reason Promise or reason.

--- a/src/FulfilledPromise.php
+++ b/src/FulfilledPromise.php
@@ -11,7 +11,7 @@ namespace GuzzleHttp\Promise;
  * immediately and ignore other callbacks.
  *
  * @template TValue = mixed
- * @template TReason = mixed
+ * @template TReason = never
  *
  * @implements PromiseInterface<TValue, TReason>
  *

--- a/src/RejectedPromise.php
+++ b/src/RejectedPromise.php
@@ -10,7 +10,7 @@ namespace GuzzleHttp\Promise;
  * Thenning off of this promise will invoke the onRejected callback
  * immediately and ignore other callbacks.
  *
- * @template TValue = mixed
+ * @template TValue = never
  * @template TReason = mixed
  *
  * @implements PromiseInterface<TValue, TReason>


### PR DESCRIPTION
A `FulfilledPromise` can never produce a rejection reason and a `RejectedPromise` can never produce a fulfilment value, yet both classes default the corresponding generic to mixed. As a result, constructing a settled promise infers a type like `RejectedPromise<mixed, Exception>`, which static analysis at stricter levels refuses to accept where a more specifically typed `PromiseInterface` is declared, forcing consumers to add inline casts. This change defaults the impossible side of each settled promise to never, the bottom type, which is accepted against any expected type argument. The same defaults are applied to the `Create::promiseFor()` and `Create::rejectionFor()` return types so promises created through the helpers infer identically to direct construction.

--

Closes #235.
