### PR TITLE
Fix EachPromise abandoning its aggregate when steps run while the iterator is locked

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@
 
 ### Fixed
 
-- Fixed `EachPromise` abandoning its aggregate when steps run while the iterator is locked
+- Fixed `EachPromise` abandoning its aggregate when the pending window drains unsettled
+- Fixed `EachPromise` admitting new work after its aggregate has settled
 
 
 ## 2.5.1 - 2026-07-08

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # CHANGELOG
 
 
+## 2.5.2 - Upcoming
+
+### Fixed
+
+- Fixed `EachPromise` abandoning its aggregate when steps run while the iterator is locked
+
+
 ## 2.5.1 - 2026-07-08
 
 ### Fixed

--- a/src/EachPromise.php
+++ b/src/EachPromise.php
@@ -140,11 +140,9 @@ class EachPromise implements PromisorInterface
                         return;
                     }
                 }
-                // Recover if steps that ran while the iterator was locked
-                // drained the window without settling the aggregate.
-                Utils::queue()->run();
-                if (Is::settled($this->aggregate) || $this->checkIfFinished()) {
-                    return;
+                // The sweep stopped early; re-sweep whatever remains.
+                if ($this->pending) {
+                    continue;
                 }
                 $this->refillPending();
                 if (!$this->pending) {

--- a/src/EachPromise.php
+++ b/src/EachPromise.php
@@ -142,7 +142,7 @@ class EachPromise implements PromisorInterface
                 }
                 // Refill and re-sweep; give up only when nothing remains.
                 $this->refillPending();
-                if (!$this->pending) {
+                if (Is::settled($this->aggregate) || !$this->pending) {
                     return;
                 }
             }
@@ -172,6 +172,10 @@ class EachPromise implements PromisorInterface
         $concurrency = is_callable($this->concurrency)
             ? ($this->concurrency)(count($this->pending))
             : $this->concurrency;
+        // The callable can settle the aggregate; admit nothing more.
+        if (Is::settled($this->aggregate)) {
+            return;
+        }
         $concurrency = max($concurrency - count($this->pending), 0);
         // Concurrency may be set to 0 to disallow new promises.
         if (!$concurrency) {

--- a/src/EachPromise.php
+++ b/src/EachPromise.php
@@ -140,10 +140,7 @@ class EachPromise implements PromisorInterface
                         return;
                     }
                 }
-                // The sweep stopped early; re-sweep whatever remains.
-                if ($this->pending) {
-                    continue;
-                }
+                // Refill and re-sweep; give up only when nothing remains.
                 $this->refillPending();
                 if (!$this->pending) {
                     return;

--- a/src/EachPromise.php
+++ b/src/EachPromise.php
@@ -34,6 +34,9 @@ class EachPromise implements PromisorInterface
     /** @var bool|null */
     private $mutex;
 
+    /** @var bool */
+    private $stepWhileLocked = false;
+
     /**
      * Configuration hash can include the following key value pairs:
      *
@@ -123,16 +126,28 @@ class EachPromise implements PromisorInterface
     {
         $this->mutex = false;
         $this->aggregate = new Promise(function (): void {
-            if ($this->checkIfFinished()) {
-                return;
-            }
-            reset($this->pending);
-            // Consume a potentially fluctuating list of promises while
-            // ensuring that indexes are maintained (precluding array_shift).
-            while ($promise = current($this->pending)) {
-                next($this->pending);
-                $promise->wait();
-                if (Is::settled($this->aggregate)) {
+            while (true) {
+                if ($this->checkIfFinished()) {
+                    return;
+                }
+                reset($this->pending);
+                // Consume a potentially fluctuating list of promises while
+                // ensuring that indexes are maintained (precluding array_shift).
+                while ($promise = current($this->pending)) {
+                    next($this->pending);
+                    $promise->wait();
+                    if (Is::settled($this->aggregate)) {
+                        return;
+                    }
+                }
+                // Recover if steps that ran while the iterator was locked
+                // drained the window without settling the aggregate.
+                Utils::queue()->run();
+                if (Is::settled($this->aggregate) || $this->checkIfFinished()) {
+                    return;
+                }
+                $this->refillPending();
+                if (!$this->pending) {
                     return;
                 }
             }
@@ -223,6 +238,8 @@ class EachPromise implements PromisorInterface
         // Place a lock on the iterator so that we ensure to not recurse,
         // preventing fatal generator errors.
         if ($this->mutex) {
+            $this->stepWhileLocked = true;
+
             return false;
         }
 
@@ -231,14 +248,22 @@ class EachPromise implements PromisorInterface
         try {
             $this->iterable->next();
             $this->mutex = false;
-
-            return true;
         } catch (\Throwable $e) {
             $this->aggregate->reject($e);
             $this->mutex = false;
 
             return false;
         }
+
+        // Run the completion check that locked steps skipped.
+        if ($this->stepWhileLocked) {
+            $this->stepWhileLocked = false;
+            if (!Is::settled($this->aggregate)) {
+                $this->checkIfFinished();
+            }
+        }
+
+        return true;
     }
 
     private function step(int $idx): void
@@ -259,6 +284,7 @@ class EachPromise implements PromisorInterface
         }
     }
 
+    /** @phpstan-impure */
     private function checkIfFinished(): bool
     {
         if (!$this->pending && !$this->iterable->valid()) {

--- a/tests/EachPromiseTest.php
+++ b/tests/EachPromiseTest.php
@@ -566,4 +566,27 @@ class EachPromiseTest extends TestCase
         $this->assertSame(3, $fulfilled);
         $this->assertSame(1, $rejected);
     }
+
+    public function testWaitRefillsAWindowReopenedByCallableConcurrency(): void
+    {
+        $calls = 0;
+        $fulfilled = [];
+        $each = new EachPromise(
+            [new FulfilledPromise('a'), new FulfilledPromise('b')],
+            [
+                // Closed at promise() time, reopens when asked again.
+                'concurrency' => static function () use (&$calls): int {
+                    return ++$calls > 1 ? 2 : 0;
+                },
+                'fulfilled' => static function ($value) use (&$fulfilled): void {
+                    $fulfilled[] = $value;
+                },
+            ]
+        );
+
+        $aggregate = $each->promise();
+        $this->assertNull($aggregate->wait());
+        $this->assertTrue(P\Is::fulfilled($aggregate));
+        $this->assertSame(['a', 'b'], $fulfilled);
+    }
 }

--- a/tests/EachPromiseTest.php
+++ b/tests/EachPromiseTest.php
@@ -572,7 +572,7 @@ class EachPromiseTest extends TestCase
         $calls = 0;
         $fulfilled = [];
         $each = new EachPromise(
-            [new FulfilledPromise('a'), new FulfilledPromise('b')],
+            [$this->createSelfResolvingPromise('a'), $this->createSelfResolvingPromise('b')],
             [
                 // Closed at promise() time, reopens when asked again.
                 'concurrency' => static function () use (&$calls): int {
@@ -588,5 +588,66 @@ class EachPromiseTest extends TestCase
         $this->assertNull($aggregate->wait());
         $this->assertTrue(P\Is::fulfilled($aggregate));
         $this->assertSame(['a', 'b'], $fulfilled);
+    }
+
+    public function testDoesNotWaitAChildAdmittedBeforeTheIteratorThrows(): void
+    {
+        $calls = 0;
+        $waited = false;
+        $child = new Promise(static function () use (&$waited): void {
+            $waited = true;
+        });
+
+        $iterator = (static function () use ($child): \Generator {
+            yield $child;
+            throw new \OutOfBoundsException('iterator failed');
+        })();
+
+        $each = new EachPromise($iterator, [
+            'concurrency' => static function () use (&$calls): int {
+                return ++$calls > 1 ? 2 : 0;
+            },
+        ]);
+
+        $aggregate = $each->promise();
+
+        try {
+            $aggregate->wait();
+            $this->fail('Expected the iterator exception to reject the aggregate.');
+        } catch (\OutOfBoundsException $e) {
+            $this->assertSame('iterator failed', $e->getMessage());
+        }
+
+        $this->assertFalse($waited);
+    }
+
+    public function testAdmitsNothingAfterTheConcurrencyCallableSettlesTheAggregate(): void
+    {
+        $produced = 0;
+        $aggregate = null;
+
+        $iterator = (static function () use (&$produced): \Generator {
+            while (true) {
+                ++$produced;
+                yield new FulfilledPromise('item');
+            }
+        })();
+
+        $each = new EachPromise($iterator, [
+            'concurrency' => static function () use (&$aggregate): int {
+                if ($aggregate !== null) {
+                    $aggregate->resolve('short-circuit');
+
+                    return 5;
+                }
+
+                return 0;
+            },
+        ]);
+
+        $aggregate = $each->promise();
+
+        $this->assertSame('short-circuit', $aggregate->wait());
+        $this->assertSame(1, $produced);
     }
 }

--- a/tests/EachPromiseTest.php
+++ b/tests/EachPromiseTest.php
@@ -485,4 +485,85 @@ class EachPromiseTest extends TestCase
         $this->assertSame(['a', 'c', 'b', 'd'], $called);
         $this->assertTrue(P\Is::fulfilled($p));
     }
+
+    public function testWaitSettlesAggregateWhenStepsRunWhileIteratorIsLocked(): void
+    {
+        // A targeted wait that settles a whole batch of transfers at once.
+        $batch = [];
+        $settleBatch = static function () use (&$batch): void {
+            foreach ($batch as $promise) {
+                $promise->resolve('done');
+            }
+            P\Utils::queue()->run();
+        };
+        $a = new Promise($settleBatch);
+        $b = new Promise($settleBatch);
+        $c = new Promise($settleBatch);
+        $batch = [$a, $b, $c];
+
+        // The drains run inside next(), so steps run while the iterator
+        // mutex is held.
+        $iterator = (static function () use ($a, $b, $c): \Generator {
+            yield $a;
+            yield $b;
+            yield $c;
+            P\Utils::queue()->run();
+            yield new RejectedPromise('failed to sign');
+            P\Utils::queue()->run();
+        })();
+
+        $fulfilled = $rejected = 0;
+        $each = new EachPromise($iterator, [
+            'concurrency' => 3,
+            'fulfilled' => static function () use (&$fulfilled): void {
+                ++$fulfilled;
+            },
+            'rejected' => static function () use (&$rejected): void {
+                ++$rejected;
+            },
+        ]);
+
+        $aggregate = $each->promise();
+        $this->assertNull($aggregate->wait());
+        $this->assertTrue(P\Is::fulfilled($aggregate));
+        $this->assertSame(3, $fulfilled);
+        $this->assertSame(1, $rejected);
+    }
+
+    public function testQueueRunSettlesAggregateWhenStepsRunWhileIteratorIsLocked(): void
+    {
+        $a = new Promise();
+        $b = new Promise();
+        $c = new Promise();
+
+        $iterator = (static function () use ($a, $b, $c): \Generator {
+            yield $a;
+            yield $b;
+            yield $c;
+            P\Utils::queue()->run();
+            yield new RejectedPromise('failed to sign');
+            P\Utils::queue()->run();
+        })();
+
+        $fulfilled = $rejected = 0;
+        $each = new EachPromise($iterator, [
+            'concurrency' => 3,
+            'fulfilled' => static function () use (&$fulfilled): void {
+                ++$fulfilled;
+            },
+            'rejected' => static function () use (&$rejected): void {
+                ++$rejected;
+            },
+        ]);
+
+        $aggregate = $each->promise();
+        $a->resolve('a');
+        $b->resolve('b');
+        $c->resolve('c');
+        P\Utils::queue()->run();
+
+        $this->assertTrue(P\Is::fulfilled($aggregate));
+        $this->assertSame(3, $fulfilled);
+        $this->assertSame(1, $rejected);
+    }
 }


### PR DESCRIPTION
EachPromise::step() skips both its completion check and its refill while the iterator mutex is held, so steps re-entered from a queue drain inside the iterator's next() can empty the pending window with nothing left to settle the aggregate. Synchronous waits then reject with the bare "Invoking the wait callback did not resolve the promise" fallback and queue-driven consumption hangs forever. This is the strongest candidate mechanism for guzzle/guzzle#3905 and the hole #237 diagnosed. advanceIterator() now runs the completion check for steps skipped under the lock, and the aggregate wait re-sweeps and refills the window instead of giving up, which also lets a callable concurrency reopen a window it had closed, without admitting or waiting further work once the aggregate has settled. The 3.0 counterpart is #239.