### PR TITLE
Document that getState() reflects settlement, not the eventual outcome

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,14 @@ You can wait for a promise to complete synchronously:
 $value = $promise->wait();
 ```
 
+A promise's `getState()` describes how it was settled, not the eventual
+outcome: a promise that was resolved with another promise, directly or by
+returning one from a `then()` handler, reports `fulfilled` while the inner
+promise may still be pending, and `wait()` can still throw if the inner
+promise rejects. Poll the state only on promises settled with plain values,
+or call `wait()` first (see
+[guzzle/promises#101](https://github.com/guzzle/promises/issues/101)).
+
 When using Guzzle HTTP requests, asynchronous methods return
 `GuzzleHttp\Promise\PromiseInterface` instances:
 

--- a/src/PromiseInterface.php
+++ b/src/PromiseInterface.php
@@ -62,7 +62,16 @@ interface PromiseInterface
      * The three states can be checked against the constants defined on
      * PromiseInterface: PENDING, FULFILLED, and REJECTED.
      *
+     * The state describes how this promise was settled, not the eventual
+     * outcome: a promise that was resolved with another promise, directly or
+     * by returning one from a then() handler, reports FULFILLED while the
+     * inner promise may still be pending, and wait() can still throw if the
+     * inner promise rejects. Poll the state only on promises settled with
+     * plain values, or call wait() first.
+     *
      * @return self::PENDING|self::FULFILLED|self::REJECTED
+     *
+     * @see https://github.com/guzzle/promises/issues/101
      */
     public function getState(): string;
 
@@ -71,7 +80,8 @@ interface PromiseInterface
      *
      * @param TValue|PromiseInterface<TValue, TReason>|null $value
      *
-     * @throws \RuntimeException if the promise is already resolved.
+     * @throws \LogicException if the promise is already settled with a
+     *                         conflicting resolution.
      */
     public function resolve($value = null): void;
 
@@ -80,7 +90,8 @@ interface PromiseInterface
      *
      * @param TReason $reason
      *
-     * @throws \RuntimeException if the promise is already resolved.
+     * @throws \LogicException if the promise is already settled with a
+     *                         conflicting resolution.
      */
     public function reject($reason): void;
 


### PR DESCRIPTION
`getState()` reports how a promise was settled rather than its eventual outcome: a promise resolved with another promise, directly or by returning one from a `then()` handler, reports fulfilled while the inner promise may still be pending, and `wait()` can still throw if the inner promise rejects. This documents that behavior on `getState()` and in the README so that state polling is not mistaken for outcome inspection, referencing #101. It also corrects the `@throws` annotations on `resolve()` and `reject()`, which declared `\RuntimeException` while the implementation throws `\LogicException`, and only for a conflicting resolution.
