### PR TITLE
Adopt the state of promises used as resolutions per Promises/A+

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,17 @@
 # CHANGELOG
 
 
+## 4.0.0 - Upcoming
+
+### Changed
+
+- Adopt the state of a promise used as a resolution, staying pending until that promise settles
+- Refuse promises as rejection reasons with an `InvalidArgumentException` instead of adopting them
+- Refuse promises in `Create::rejectionFor()` instead of returning them as-is
+- Reject with a `TypeError` instead of throwing when a promise is resolved or rejected with itself
+- Ignore resolutions of a promise while it adopts the state of another promise
+- Forward cancellation to the adopted promise when a promise adopting one is cancelled
+
 ## 3.0.1 - 2026-08-05
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -50,13 +50,13 @@ You can wait for a promise to complete synchronously:
 $value = $promise->wait();
 ```
 
-A promise's `getState()` describes how it was settled, not the eventual
-outcome: a promise that was resolved with another promise, directly or by
-returning one from a `then()` handler, reports `fulfilled` while the inner
-promise may still be pending, and `wait()` can still throw if the inner
-promise rejects. Poll the state only on promises settled with plain values,
-or call `wait()` first (see
-[guzzle/promises#101](https://github.com/guzzle/promises/issues/101)).
+A promise that is resolved with another promise, directly or by returning one
+from a `then()` handler, adopts that promise's eventual state: it stays
+`pending` until the other promise settles, so `getState()` always describes
+the final outcome
+([guzzle/promises#101](https://github.com/guzzle/promises/issues/101)).
+Rejection reasons are never promises; rejecting with one throws an
+`InvalidArgumentException`.
 
 When using Guzzle HTTP requests, asynchronous methods return
 `GuzzleHttp\Promise\PromiseInterface` instances:

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,6 +1,31 @@
 Guzzle Promises Upgrade Guide
 =============================
 
+3.x to 4.0
+----------
+
+Guzzle Promises 4.0 makes the promise state model conform to Promises/A+.
+
+#### Promise State Adoption
+
+`resolve()` with a promise or other thenable, including returning one from a
+`then()` handler, no longer settles the promise immediately. The promise stays
+pending and adopts the thenable's eventual state (Promises/A+ Section 2.3.2),
+so `getState()` reports `fulfilled` or `rejected` only once the final outcome
+is known. The state of an already-settled promise is adopted synchronously.
+Code that polls `getState()` on chained promises observes `pending` where 3.x
+reported a settled state; `wait()` and `then()` behave as before. Resolutions
+arriving while a promise adopts another promise are ignored instead of
+throwing, and cancelling an adopting promise now cancels the adopted promise.
+
+#### Rejection Reasons
+
+Rejection reasons are never adopted. `reject()` and `Create::rejectionFor()`
+throw an `InvalidArgumentException` for a promise or other thenable reason,
+where 3.x silently adopted the promise's eventual state. Resolving or
+rejecting a promise with itself now rejects it with a `TypeError` instead of
+throwing a `LogicException`.
+
 2.x to 3.0
 ----------
 

--- a/src/Create.php
+++ b/src/Create.php
@@ -56,7 +56,7 @@ final class Create
     public static function rejectionFor($reason): PromiseInterface
     {
         if ($reason instanceof PromiseInterface) {
-            return $reason;
+            throw new \InvalidArgumentException('You cannot reject a promise with another promise.');
         }
 
         return new RejectedPromise($reason);

--- a/src/FulfilledPromise.php
+++ b/src/FulfilledPromise.php
@@ -37,6 +37,18 @@ class FulfilledPromise implements PromiseInterface
     }
 
     /**
+     * Returns the fulfillment value.
+     *
+     * @return TValue
+     *
+     * @internal
+     */
+    public function value()
+    {
+        return $this->value;
+    }
+
+    /**
      * @template TFulfilledValue = never
      * @template TFulfilledReason = never
      * @template TRejectedValue = never

--- a/src/Promise.php
+++ b/src/Promise.php
@@ -29,6 +29,14 @@ class Promise implements PromiseInterface
     /** @var (callable(): void)|null */
     private $cancelFn;
 
+    /**
+     * Thenable this promise is locked to while it adopts the thenable's
+     * eventual state (Promises/A+ 2.3.2). While set, the promise is
+     * "resolved but pending": it stays pending and ignores further calls
+     * to resolve() and reject() (Promises/A+ 2.3.3.3.3).
+     */
+    private ?object $adopted = null;
+
     /** @var (callable(bool): void)|null */
     private $waitFn;
 
@@ -83,12 +91,30 @@ class Promise implements PromiseInterface
 
         // It's either cancelled or rejected, so return a rejected promise
         // and immediately invoke any callbacks.
-        $rejection = Create::rejectionFor($this->result);
+        if (!is_object($this->result) || !method_exists($this->result, 'then')) {
+            $rejection = Create::rejectionFor($this->result);
 
-        /** @var PromiseInterface<($onFulfilled is null ? TValue : TFulfilledValue)|($onRejected is null ? never : TRejectedValue), ($onFulfilled is null ? never : TFulfilledReason|\Throwable)|($onRejected is null ? TReason : TRejectedReason|\Throwable)> $promise */
-        $promise = $onRejected ? $rejection->then(null, $onRejected) : $rejection;
+            /** @var PromiseInterface<($onFulfilled is null ? TValue : TFulfilledValue)|($onRejected is null ? never : TRejectedValue), ($onFulfilled is null ? never : TFulfilledReason|\Throwable)|($onRejected is null ? TReason : TRejectedReason|\Throwable)> $promise */
+            $promise = $onRejected ? $rejection->then(null, $onRejected) : $rejection;
 
-        return $promise;
+            return $promise;
+        }
+
+        // The reason is a thenable rejection reason adopted verbatim from
+        // another implementation; it is passed to handlers verbatim as well,
+        // as rejection reasons are never adopted.
+        if (!$onRejected) {
+            return $this;
+        }
+
+        $queue = Utils::queue();
+        $p = new Promise([$queue, 'run']);
+        $reason = $this->result;
+        $queue->add(static function () use ($p, $reason, $onFulfilled, $onRejected): void {
+            self::callHandler(2, $reason, [$p, $onFulfilled, $onRejected]);
+        });
+
+        return $p;
     }
 
     /**
@@ -108,9 +134,6 @@ class Promise implements PromiseInterface
     {
         $this->waitIfPending();
 
-        if ($this->result instanceof PromiseInterface) {
-            return $this->result->wait($unwrap);
-        }
         if ($unwrap) {
             if ($this->state === self::FULFILLED) {
                 return $this->result;
@@ -134,6 +157,16 @@ class Promise implements PromiseInterface
         }
 
         $this->waitFn = $this->waitList = null;
+
+        // Cancelling a promise that adopted another thenable's state also
+        // cancels the adopted thenable and unlocks this promise so that the
+        // rejection below can take effect.
+        if (null !== $adopted = $this->adopted) {
+            $this->adopted = null;
+            if (method_exists($adopted, 'cancel')) {
+                $adopted->cancel();
+            }
+        }
 
         if ($this->cancelFn) {
             $fn = $this->cancelFn;
@@ -164,6 +197,13 @@ class Promise implements PromiseInterface
 
     private function settle(string $state, $value): void
     {
+        if ($this->adopted !== null) {
+            // The promise already adopts the state of another thenable, so
+            // its fate is locked and further resolutions are ignored
+            // (Promises/A+ 2.3.3.3.3).
+            return;
+        }
+
         if ($this->state !== self::PENDING) {
             // Ignore calls with the same resolution.
             if ($state === $this->state && $value === $this->result) {
@@ -175,9 +215,34 @@ class Promise implements PromiseInterface
         }
 
         if ($value === $this) {
-            throw new \LogicException('Cannot fulfill or reject a promise with itself');
+            // Reject with a \TypeError instead (Promises/A+ 2.3.1).
+            $state = self::REJECTED;
+            $value = new \TypeError('Cannot fulfill or reject a promise with itself');
         }
 
+        if (is_object($value) && method_exists($value, 'then')) {
+            if ($state === self::REJECTED) {
+                throw new \InvalidArgumentException('You cannot reject a promise with another promise.');
+            }
+
+            // Resolving with a thenable does not settle the promise. Instead
+            // the promise stays pending and adopts the thenable's eventual
+            // state (Promises/A+ 2.3.2).
+            $this->adopt($value);
+
+            return;
+        }
+
+        $this->settleWith($state, $value);
+    }
+
+    /**
+     * Settles the promise with a resolution that already passed the
+     * resolution procedure: the value of a fulfillment is never a thenable,
+     * and a rejection reason stays verbatim (Promises/A+ 2.3.2.3).
+     */
+    private function settleWith(string $state, $value): void
+    {
         // Clear out the state of the promise but stash the handlers.
         $this->state = $state;
         $this->result = $value;
@@ -185,39 +250,82 @@ class Promise implements PromiseInterface
         $this->handlers = null;
         $this->waitList = $this->waitFn = null;
         $this->cancelFn = null;
+        $this->adopted = null;
 
         if (!$handlers) {
             return;
         }
 
-        // If the value was not a settled promise or a thenable, then resolve
-        // it in the task queue using the correct ID.
-        if (!is_object($value) || !method_exists($value, 'then')) {
-            $id = $state === self::FULFILLED ? 1 : 2;
-            // It's a success, so resolve the handlers in the queue.
-            Utils::queue()->add(static function () use ($id, $value, $handlers): void {
-                foreach ($handlers as $handler) {
-                    self::callHandler($id, $value, $handler);
-                }
-            });
-        } elseif ($value instanceof Promise && Is::pending($value)) {
-            // We can just merge our handlers onto the next promise.
-            $value->handlers = array_merge($value->handlers, $handlers);
-        } else {
-            // Resolve the handlers when the forwarded promise is resolved.
-            $value->then(
-                static function ($value) use ($handlers): void {
-                    foreach ($handlers as $handler) {
-                        self::callHandler(1, $value, $handler);
-                    }
-                },
-                static function ($reason) use ($handlers): void {
-                    foreach ($handlers as $handler) {
-                        self::callHandler(2, $reason, $handler);
-                    }
-                }
-            );
+        $id = $state === self::FULFILLED ? 1 : 2;
+        Utils::queue()->add(static function () use ($id, $value, $handlers): void {
+            foreach ($handlers as $handler) {
+                self::callHandler($id, $value, $handler);
+            }
+        });
+    }
+
+    /**
+     * Locks this promise to a thenable so that it adopts the thenable's
+     * eventual state (Promises/A+ 2.3.2), staying pending until it settles.
+     *
+     * The state of an already-settled promise is adopted synchronously:
+     * Promises/A+ only observes state through then() callbacks, which stay
+     * asynchronous.
+     */
+    private function adopt(object $thenable): void
+    {
+        if ($thenable instanceof FulfilledPromise) {
+            $this->settleWith(self::FULFILLED, $thenable->value());
+
+            return;
         }
+
+        if ($thenable instanceof RejectedPromise) {
+            $this->settleWith(self::REJECTED, $thenable->reason());
+
+            return;
+        }
+
+        if ($thenable instanceof self && $thenable->state !== self::PENDING) {
+            $this->settleWith($thenable->state, $thenable->result);
+
+            return;
+        }
+
+        $this->adopted = $thenable;
+        // The resolver has committed to the thenable, so the original wait
+        // and cancel functions no longer apply; waiting and cancellation are
+        // forwarded to the adopted thenable instead.
+        $this->waitFn = $this->waitList = null;
+        $this->cancelFn = null;
+
+        if ($thenable instanceof self) {
+            // Merge the handlers onto the adopted promise behind a marker
+            // entry that settles this promise first, keeping dispatch as flat
+            // as merging handlers onto the next promise did before adoption.
+            $thenable->handlers[] = [$this, null, null, true];
+            if ($this->handlers) {
+                $thenable->handlers = array_merge($thenable->handlers, $this->handlers);
+            }
+            $this->handlers = [];
+
+            return;
+        }
+
+        $thenable->then(
+            function ($value) use ($thenable): void {
+                if ($this->adopted === $thenable) {
+                    $this->adopted = null;
+                    $this->settleWith(self::FULFILLED, $value);
+                }
+            },
+            function ($reason) use ($thenable): void {
+                if ($this->adopted === $thenable) {
+                    $this->adopted = null;
+                    $this->settleWith(self::REJECTED, $reason);
+                }
+            }
+        );
     }
 
     /**
@@ -231,6 +339,17 @@ class Promise implements PromiseInterface
     {
         /** @var PromiseInterface<mixed, mixed> $promise */
         $promise = $handler[0];
+
+        if (isset($handler[3])) {
+            // Adoption marker: the promise adopts this settlement directly,
+            // unless cancellation already unlocked it.
+            if ($promise instanceof self && $promise->adopted !== null) {
+                $promise->adopted = null;
+                $promise->settleWith($index === 1 ? self::FULFILLED : self::REJECTED, $value);
+            }
+
+            return;
+        }
 
         // The promise may have been cancelled or resolved before placing
         // this thunk in the queue.
@@ -269,7 +388,7 @@ class Promise implements PromiseInterface
             $this->invokeWaitFn();
         } elseif ($this->waitList) {
             $this->invokeWaitList();
-        } else {
+        } elseif ($this->adopted === null) {
             // If there's no wait function, then reject the promise.
             $this->reject('Cannot wait on a promise that has '
                 .'no internal wait function. You must provide a wait '
@@ -279,8 +398,26 @@ class Promise implements PromiseInterface
 
         Utils::queue()->run();
 
+        // Waiting on a promise that adopted a thenable's state waits on the
+        // thenable, repeatedly in case the thenable settles with yet another
+        // thenable that is adopted in turn. The promise is pending as long
+        // as it is locked to an adopted thenable.
+        while (null !== $adopted = $this->adopted) {
+            if (!method_exists($adopted, 'wait')) {
+                break;
+            }
+            $adopted->wait(false);
+            Utils::queue()->run();
+            if ($this->adopted === $adopted) {
+                // Waiting on the adopted thenable did not settle it.
+                break;
+            }
+        }
+
         /** @psalm-suppress RedundantCondition */
         if ($this->state === self::PENDING) {
+            // Unlock the promise so that the rejection can take effect.
+            $this->adopted = null;
             $this->reject('Invoking the wait callback did not resolve the promise');
         }
     }
@@ -292,7 +429,7 @@ class Promise implements PromiseInterface
             $this->waitFn = null;
             $wfn(true);
         } catch (\Throwable $reason) {
-            if ($this->state === self::PENDING) {
+            if ($this->state === self::PENDING && $this->adopted === null) {
                 // The promise has not been resolved yet, so reject the promise
                 // with the exception.
                 $this->reject($reason);
@@ -310,14 +447,10 @@ class Promise implements PromiseInterface
         $this->waitList = null;
 
         foreach ($waitList as $result) {
-            do {
-                $result->waitIfPending();
-                $result = $result->result;
-            } while ($result instanceof Promise);
-
-            if ($result instanceof PromiseInterface) {
-                $result->wait(false);
-            }
+            // A settled promise never holds another promise as its result:
+            // fulfillment values are adopted and thenable rejection reasons
+            // are refused, so there is no result chain to follow.
+            $result->waitIfPending();
         }
     }
 }

--- a/src/PromiseInterface.php
+++ b/src/PromiseInterface.php
@@ -62,12 +62,11 @@ interface PromiseInterface
      * The three states can be checked against the constants defined on
      * PromiseInterface: PENDING, FULFILLED, and REJECTED.
      *
-     * The state describes how this promise was settled, not the eventual
-     * outcome: a promise that was resolved with another promise, directly or
-     * by returning one from a then() handler, reports FULFILLED while the
-     * inner promise may still be pending, and wait() can still throw if the
-     * inner promise rejects. Poll the state only on promises settled with
-     * plain values, or call wait() first.
+     * A promise that was resolved with another promise, directly or by
+     * returning one from a then() handler, adopts that promise's state: it
+     * stays PENDING until the other promise settles (Promises/A+ 2.3.2), so
+     * FULFILLED and REJECTED always describe the final outcome and wait()
+     * settles accordingly without further work.
      *
      * @return self::PENDING|self::FULFILLED|self::REJECTED
      *
@@ -77,6 +76,9 @@ interface PromiseInterface
 
     /**
      * Resolve the promise with the given value, or with null if no value is given.
+     *
+     * Resolving with a promise or other thenable makes this promise adopt
+     * its eventual state, staying pending until it settles.
      *
      * @param TValue|PromiseInterface<TValue, TReason>|null $value
      *
@@ -90,8 +92,10 @@ interface PromiseInterface
      *
      * @param TReason $reason
      *
-     * @throws \LogicException if the promise is already settled with a
-     *                         conflicting resolution.
+     * @throws \InvalidArgumentException if the reason is a promise or other
+     *                                   thenable.
+     * @throws \LogicException           if the promise is already settled with a
+     *                                   conflicting resolution.
      */
     public function reject($reason): void;
 

--- a/src/RejectedPromise.php
+++ b/src/RejectedPromise.php
@@ -37,6 +37,18 @@ class RejectedPromise implements PromiseInterface
     }
 
     /**
+     * Returns the rejection reason.
+     *
+     * @return TReason
+     *
+     * @internal
+     */
+    public function reason()
+    {
+        return $this->reason;
+    }
+
+    /**
      * @template TFulfilledValue = never
      * @template TFulfilledReason = never
      * @template TRejectedValue = never

--- a/tests/CreateTest.php
+++ b/tests/CreateTest.php
@@ -43,11 +43,12 @@ class CreateTest extends TestCase
         $this->assertSame('fail', PropertyHelper::get($p, 'reason'));
     }
 
-    public function testReturnsPromisesAsIsInRejectionFor(): void
+    public function testRefusesPromisesInRejectionFor(): void
     {
-        $a = new Promise();
-        $b = P\Create::rejectionFor($a);
-        $this->assertSame($a, $b);
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('You cannot reject a promise with another promise.');
+
+        P\Create::rejectionFor(new Promise());
     }
 
     public function testIterForReturnsIterator(): void

--- a/tests/PromiseTest.php
+++ b/tests/PromiseTest.php
@@ -239,12 +239,144 @@ class PromiseTest extends TestCase
             $p3->resolve('Whoop');
         });
         $p2 = new Promise(function () use (&$p2, $p3): void {
-            $p2->reject($p3);
+            $p2->resolve($p3);
         });
         $p = new Promise(function () use (&$p, $p2): void {
-            $p->reject($p2);
+            $p->resolve($p2);
         });
         $this->assertSame('Whoop', $p->wait());
+    }
+
+    public function testCannotRejectWithAPromise(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('You cannot reject a promise with another promise.');
+
+        $p = new Promise();
+        $p->reject(new Promise());
+    }
+
+    public function testRemainsPendingWhenResolvedWithPendingPromise(): void
+    {
+        $p = new Promise();
+        $inner = new Promise();
+        $p->resolve($inner);
+
+        $this->assertTrue(P\Is::pending($p));
+
+        $inner->resolve('foo');
+        P\Utils::queue()->run();
+
+        $this->assertTrue(P\Is::fulfilled($p));
+        $this->assertSame('foo', $p->wait());
+    }
+
+    public function testNeverReportsFulfilledWhenResolvedWithPromiseThatLaterRejects(): void
+    {
+        $p = new Promise();
+        $inner = new Promise();
+        $p->resolve($inner);
+
+        $this->assertTrue(P\Is::pending($p));
+
+        $inner->reject('bar');
+        P\Utils::queue()->run();
+
+        $this->assertTrue(P\Is::rejected($p));
+
+        try {
+            $p->wait();
+            $this->fail();
+        } catch (RejectionException $e) {
+            $this->assertSame('bar', $e->getReason());
+        }
+    }
+
+    public function testAdoptsStateOfSettledPromiseSynchronously(): void
+    {
+        $p = new Promise();
+        $p->resolve(new FulfilledPromise('foo'));
+
+        // A+ only observes state through then() callbacks, so the state of an
+        // already-settled promise can be adopted without a queue tick.
+        $this->assertTrue(P\Is::fulfilled($p));
+        $this->assertSame('foo', $p->wait());
+
+        $r = new Promise();
+        $r->resolve(new RejectedPromise('bar'));
+
+        $this->assertTrue(P\Is::rejected($r));
+    }
+
+    public function testIgnoresResolutionsWhileAdoptingStateOfAnotherPromise(): void
+    {
+        $p = new Promise();
+        $inner = new Promise();
+        $p->resolve($inner);
+        $p->resolve('other');
+        $p->reject('nope');
+
+        $inner->resolve('kept');
+        P\Utils::queue()->run();
+
+        $this->assertTrue(P\Is::fulfilled($p));
+        $this->assertSame('kept', $p->wait());
+    }
+
+    public function testCancelsAdoptedPromiseWhenCancelled(): void
+    {
+        $p = new Promise();
+        $inner = new Promise();
+        $p->resolve($inner);
+        $p->cancel();
+        P\Utils::queue()->run();
+
+        $this->assertTrue(P\Is::rejected($p));
+        $this->assertTrue(P\Is::rejected($inner));
+    }
+
+    public function testAdoptsStateOfDuckTypedThenable(): void
+    {
+        $thenable = new class {
+            /** @var callable|null */
+            public $onFulfilled;
+
+            public function then(?callable $onFulfilled = null, ?callable $onRejected = null): void
+            {
+                $this->onFulfilled = $onFulfilled;
+            }
+        };
+
+        $p = new Promise();
+        $p->resolve($thenable);
+
+        $this->assertTrue(P\Is::pending($p));
+
+        ($thenable->onFulfilled)('foo');
+
+        $this->assertTrue(P\Is::fulfilled($p));
+        $this->assertSame('foo', $p->wait());
+    }
+
+    public function testDispatchesHandlersAttachedBeforeAdoption(): void
+    {
+        $p = new Promise();
+        $results = [];
+        $p->then(static function ($value) use (&$results): void {
+            $results[] = 'first:'.$value;
+        });
+
+        $inner = new Promise();
+        $p->resolve($inner);
+        $p->then(static function ($value) use (&$results): void {
+            $results[] = 'second:'.$value;
+        });
+
+        $inner->resolve('foo');
+        P\Utils::queue()->run();
+
+        $this->assertTrue(P\Is::fulfilled($p));
+        $this->assertSame(['first:foo', 'second:foo'], $results);
     }
 
     public function testWaitsOnAPromiseChainEvenWhenNotUnwrapped(): void
@@ -789,22 +921,34 @@ class PromiseTest extends TestCase
         $this->assertSame(['B', 'D:a', 'A:foo', 'C:foo'], $res);
     }
 
-    public function testCannotResolveWithSelf(): void
+    public function testRejectsWithTypeErrorWhenResolvedWithSelf(): void
     {
-        $this->expectException(\LogicException::class);
-        $this->expectExceptionMessage('Cannot fulfill or reject a promise with itself');
-
         $p = new Promise();
         $p->resolve($p);
+
+        $this->assertTrue(P\Is::rejected($p));
+
+        try {
+            $p->wait();
+            $this->fail();
+        } catch (\TypeError $e) {
+            $this->assertSame('Cannot fulfill or reject a promise with itself', $e->getMessage());
+        }
     }
 
-    public function testCannotRejectWithSelf(): void
+    public function testRejectsWithTypeErrorWhenRejectedWithSelf(): void
     {
-        $this->expectException(\LogicException::class);
-        $this->expectExceptionMessage('Cannot fulfill or reject a promise with itself');
-
         $p = new Promise();
         $p->reject($p);
+
+        $this->assertTrue(P\Is::rejected($p));
+
+        try {
+            $p->wait();
+            $this->fail();
+        } catch (\TypeError $e) {
+            $this->assertSame('Cannot fulfill or reject a promise with itself', $e->getMessage());
+        }
     }
 
     public function testDoesNotBlowStackWhenWaitingOnNestedThens(): void


### PR DESCRIPTION
Resolving a promise with another promise, or returning one from a `then()` handler, settled the promise immediately: `getState()` reported `fulfilled` while the inner promise was still pending, and `wait()` could later throw on a promise whose state said it had fulfilled, violating Promises/A+ section 2.3.2. The promise now stays pending and adopts the thenable's eventual state, adopting an already-settled promise synchronously so that state polling around the synchronous `wait()` path keeps working. Handlers attached before adoption are merged onto the adopted promise behind a marker entry, which keeps dispatch as flat as the previous handler merge; a 5000-deep resolution chain runs within about 1.6 times the 3.x time while using a quarter of the memory. Rejection reasons are never adopted: `reject()` and `Create::rejectionFor()` now refuse promises with an `InvalidArgumentException`, matching `RejectedPromise`, and resolving or rejecting a promise with itself rejects it with a `TypeError` per section 2.3.1. Resolutions arriving while a promise adopts another promise are ignored per section 2.3.3.3.3, and cancelling an adopting promise forwards the cancellation to the adopted promise. Guzzle's full test suite passes unchanged against this branch. Drafted against 3.0 until a 4.0 branch is cut. Fixes #101.
