### PR TITLE
Add PHP 8.6 to the CI matrix and version guidance

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
       fail-fast: false
       max-parallel: 10
       matrix:
-        php: ['7.4', '8.0', '8.1', '8.2', '8.3', '8.4', '8.5']
+        php: ['7.4', '8.0', '8.1', '8.2', '8.3', '8.4', '8.5', '8.6']
 
     steps:
       - name: Set up PHP

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 
 ### Added
 
-- Added PHP 8.6 to the supported and tested versions
+- Added support for PHP 8.6
 
 
 ## 3.0.1 - 2026-08-05

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # CHANGELOG
 
 
+## 3.0.2 - Upcoming
+
+### Added
+
+- Added PHP 8.6 to the supported and tested versions
+
+
 ## 3.0.1 - 2026-08-05
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ composer require guzzlehttp/promises
 
 | Version | Status       | PHP Version  |
 |---------|--------------|--------------|
-| 3.0     | Latest       | >=7.4,<8.6   |
-| 2.5     | Maintenance  | >=7.2.5,<8.6 |
+| 3.0     | Latest       | >=7.4,<8.7   |
+| 2.5     | Maintenance  | >=7.2.5,<8.7 |
 | 1.5     | End of Life  | >=5.5,<8.3   |
 
 ## Quick Start


### PR DESCRIPTION
The full test suite passes under PHP 8.6.0beta1 without code changes, so this adds PHP 8.6 to the CI matrix and version guidance.
